### PR TITLE
added block size in naoqi microphone params config

### DIFF
--- a/sic_framework/devices/common_naoqi/naoqi_microphone.py
+++ b/sic_framework/devices/common_naoqi/naoqi_microphone.py
@@ -16,6 +16,7 @@ class NaoqiMicrophoneConf(SICConfMessage):
         self.no_channels = 1
         self.sample_rate = 16000
         self.index = -1
+        self.block_size = 0
 
 
 class NaoqiMicrophoneSensor(SICSensor):
@@ -41,7 +42,7 @@ class NaoqiMicrophoneSensor(SICSensor):
             )
 
         self.audio_service.setClientPreferences(
-            self.module_name, self.params.sample_rate, self.params.channel_index, 0
+            self.module_name, self.params.sample_rate, self.params.channel_index, self.params.block_size
         )
         self.audio_service.subscribe(self.module_name)
 


### PR DESCRIPTION
I noticed that it was not possible to change the block size, which can break integration with some models.
I suggest adding this parameter to the naoqi microphone config.
I kept the default at 0 samples, but I personally would suggest something in the line of 0.5s for the samplerate. 8000 samples for 16khz samplerate for example