### PR TITLE
now auto installing dependencies on Pepper

### DIFF
--- a/sic_framework/devices/device.py
+++ b/sic_framework/devices/device.py
@@ -17,24 +17,42 @@ if six.PY3:
     from scp import SCPClient
 
 
-class _SICLibrary(object):
+class SICLibrary(object):
     """
     A library to be installed on a remote device.
     """
 
-    def __init__(self, name, lib_path, lib_install_cmd):
+    def __init__(self, name, lib_path="", download_cmd="", version=None, lib_install_cmd=""):
         self.name = name
         self.lib_path = lib_path
+        self.download_cmd = download_cmd
+        self.version = version
         self.lib_install_cmd = lib_install_cmd
 
     def check_if_installed(self, pip_freeze):
         for lib in pip_freeze:
-            if self.name in lib:
+            lib = lib.replace('\n','')
+            lib_name, lib_ver = lib.split('==')
+            if self.name == lib_name:
+                print("Found package: {}".format(lib))
+                # check to make sure version matches 
+                if self.version:
+                    if self.version in lib_ver:
+                        return True
+                    else:
+                        return False
                 return True
         return False
-
+    
     def install(self, ssh):
         print("Installing {} on remote device ".format(self.name), end="")
+
+        # if we have to download the binary first, as is the case with Pepper
+        if self.download_cmd:
+            stdin, stdout, stderr = ssh.exec_command(
+                "cd {} && {}".format(self.lib_path, self.download_cmd)
+            )
+
         stdin, stdout, stderr = ssh.exec_command(
             "cd {} && {}".format(self.lib_path, self.lib_install_cmd)
         )
@@ -57,21 +75,6 @@ class _SICLibrary(object):
             )
         else:
             print(" done.")
-
-
-_LIBS_TO_INSTALL = [
-    _SICLibrary(
-        "redis",
-        "~/framework/lib/redis",
-        "pip install --user redis-3.5.3-py2.py3-none-any.whl",
-    ),
-    _SICLibrary(
-        "PyTurboJPEG",
-        "~/framework/lib/libtubojpeg/PyTurboJPEG-master",
-        "pip install --user .",
-    ),
-    _SICLibrary("sic-framework", "~/framework", "pip install --user -e ."),
-]
 
 
 def exclude_pyc(tarinfo):


### PR DESCRIPTION
Reuses old code to install libraries. Decided to use curl to download binaries off of the web--may have to change URLs if PyPi reorganizes, but this method was chosen over hosting more binaries in the repo. Dependencies are checked right after SIC is installed. If SIC is already installed, it is assumed that all the dependencies are already installed. We could check if the dependencies are installed regardless if SIC is, but it's likely not necessary and would add a few seconds to startup every time due to the 'pip freeze' command.