### PR TITLE
Improve MiniSpeakerComponent 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ extras_require = {
 
 setup(
     name="social-interaction-cloud",
-    version="2.0.26",
+    version="2.0.27",
     author="Koen Hindriks",
     author_email="k.v.hindriks@vu.nl",
     long_description=open("README.md").read(),

--- a/sic_framework/devices/__init__.py
+++ b/sic_framework/devices/__init__.py
@@ -1,3 +1,2 @@
 from .nao import Nao
 from .pepper import Pepper
-from .alphamini import Alphamini

--- a/sic_framework/devices/common_mini/mini_speaker.py
+++ b/sic_framework/devices/common_mini/mini_speaker.py
@@ -1,15 +1,11 @@
-import asyncio
-import os
-import wave
+import pyaudio
 
 from sic_framework import SICComponentManager
 from sic_framework.core.component_python2 import SICComponent
 from sic_framework.core.connector import SICConnector
-from sic_framework.core.message_python2 import AudioMessage, SICConfMessage, SICMessage
-
-import mini.pkg_tool as Tool
-
-from sic_framework.devices.common_mini.mini_connector import MiniConnector
+from sic_framework.core.message_python2 import (
+    AudioMessage, SICConfMessage, SICMessage
+)
 
 
 class MiniSpeakersConf(SICConfMessage):
@@ -21,9 +17,17 @@ class MiniSpeakersConf(SICConfMessage):
 class MiniSpeakerComponent(SICComponent):
     def __init__(self, *args, **kwargs):
         super(MiniSpeakerComponent, self).__init__(*args, **kwargs)
-        self.alphamini = MiniConnector()
-        self.alphamini.connect()
-        self.i = 0
+
+
+        self.device = pyaudio.PyAudio()
+        # open an audio stream
+        self.stream = self.device.open(
+            format=pyaudio.paInt16,
+            channels=self.params.channels,
+            rate=self.params.sample_rate,
+            input=False,
+            output=True,
+        )
 
     @staticmethod
     def get_conf():
@@ -31,50 +35,25 @@ class MiniSpeakerComponent(SICComponent):
 
     @staticmethod
     def get_inputs():
-        return []
+        return [AudioMessage]
 
     @staticmethod
     def get_output():
         return SICMessage
 
     def on_message(self, message):
-        self.play_sound(message)
+        self.stream.write(message.waveform)
 
     def on_request(self, request):
-        self.play_sound(request)
+        self.stream.write(request.waveform)
         return SICMessage()
 
-    def play_sound(self, message):
-        bytestream = message.waveform
-        frame_rate = message.sample_rate
+    def stop(self, *args):
+        super(MiniSpeakerComponent, self).stop(*args)
+        self.logger.info("Stopped speakers")
 
-        # # Create the directory tmp directory in the home folder if it doesn't exist
-        tmp_path = "/data/data/com.termux/files/home/tmp/"
-        os.makedirs(os.path.dirname(tmp_path), exist_ok=True)
-        # # Define the file path for the temp audio file
-        tmp_file = tmp_path + f"tmp{self.i}.wav"
-
-        # Set the parameters for the WAV file
-        channels = 1  # 1 for mono audio
-        sample_width = 2  # 2 bytes for 16-bit audio
-        num_frames = len(bytestream) // (channels * sample_width)
-
-        with wave.open(tmp_file, "wb") as wav_file:
-            wav_file.setparams(
-                (channels, sample_width, frame_rate, num_frames, "NONE", "not compressed")
-            )
-            wav_file.writeframes(bytestream)
-        self.i += 1
-
-        # Ensure an event loop exists in the current thread
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-
-        # Play the audio file
-        Tool.run_py_pkg(f'play {tmp_file}', robot_id=self.alphamini.mini_id, debug=True)
+        self.stream.close()
+        self.device.terminate()
 
 
 class MiniSpeaker(SICConnector):


### PR DESCRIPTION
Issue number: resolves #33 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
As mentioned in #33, using Sox to play audio is not stable, as the process gets stuck after one play, causing the next round to fail. Additionally, saving to a `.wav` file creates unnecessary overhead. Since we can play audio directly using pyaudio, saving is not required. Also, using `Tool.run_py_pkg` to send commands is unnecessary, as `MiniSpeakerComponent` is already running on the device.

## What is the new behavior?
The MiniSpeakerComponent is now smoother, and no processes get stuck.

