### PR TITLE
Make start-up of alphamini device more robust

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,8 @@ extras_require = {
     ],
     "alphamini": [
         "alphamini",
-        "protobuf~=3.20.2",
-        "websockets~=13.0",
+        "protobuf~=3.20.3",
+        "websockets~=13.1",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ extras_require = {
 
 setup(
     name="social-interaction-cloud",
-    version="2.0.27",
+    version="2.0.28",
     author="Koen Hindriks",
     author_email="k.v.hindriks@vu.nl",
     long_description=open("README.md").read(),

--- a/sic_framework/devices/common_mini/mini_animation.py
+++ b/sic_framework/devices/common_mini/mini_animation.py
@@ -23,6 +23,8 @@ class MiniActionRequest(SICRequest):
 
 
 class MiniAnimationActuator(SICActuator):
+    COMPONENT_STARTUP_TIMEOUT = 5
+
     def __init__(self, *args, **kwargs):
         SICActuator.__init__(self, *args, **kwargs)
 

--- a/sic_framework/devices/common_mini/mini_speaker.py
+++ b/sic_framework/devices/common_mini/mini_speaker.py
@@ -15,6 +15,8 @@ class MiniSpeakersConf(SICConfMessage):
 
 
 class MiniSpeakerComponent(SICComponent):
+    COMPONENT_STARTUP_TIMEOUT = 5
+
     def __init__(self, *args, **kwargs):
         super(MiniSpeakerComponent, self).__init__(*args, **kwargs)
 

--- a/sic_framework/devices/device.py
+++ b/sic_framework/devices/device.py
@@ -81,11 +81,11 @@ class SICDevice(object):
     def __new__(cls, *args, **kwargs):
         """ Choose specific imports dependend on the type of device.
 
-        Reasoning: alphamini do not support these imports, they are only needed for remotely installing pkgs for Nao and Pepper
+        Reasoning: Alphamini does not support these imports; they are only needed for remotely installing packages on robots from the local machine
         """
         instance = super(SICDevice, cls).__new__(cls)
 
-        if cls.__name__ in ("Nao", "Pepper"):
+        if cls.__name__ in ("Nao", "Pepper", "Alphamini"):
             import six
             if six.PY3:
                 global pathlib, paramiko, SCPClient
@@ -95,7 +95,7 @@ class SICDevice(object):
 
         return instance
 
-    def __init__(self, ip, username=None, passwords=None):
+    def __init__(self, ip, username=None, passwords=None, port=22):
         """
         Connect to the device and ensure an up to date version of the framework is installed
         :param ip: the ip adress of the device
@@ -105,13 +105,14 @@ class SICDevice(object):
         self.connectors = dict()
         self.configs = dict()
         self.ip = ip
+        self.port = port
 
         if username is not None:
 
             if not isinstance(passwords, list):
                 passwords = [passwords]
 
-            if not utils.ping_server(self.ip, port=22, timeout=3):
+            if not utils.ping_server(self.ip, port=self.port, timeout=3):
                 raise RuntimeError(
                     "Could not connect to device on ip {}. Please check if it is reachable.".format(
                         self.ip
@@ -125,7 +126,7 @@ class SICDevice(object):
                 try:
                     self.ssh.connect(
                         self.ip,
-                        port=22,
+                        port=self.port,
                         username=username,
                         password=p,
                         timeout=3,


### PR DESCRIPTION
Issue number: 31

---------

## What is the current behavior?
Currently the speaker component start after a request is send. The current work around is to call a request twice (or run the application twice) and add sleep to make sure everything is started correctly before handling the request.

## What is the new behavior?
This PR 

1. Fixes issue #31, where components were starting after sending the audio request. Previously, the SIC installation was running in a separate thread, causing the main thread to continue without waiting for SIC to finish installing and running the `alphamini.py` on a remote mini. Now, `sic_install` is blocking.

2. Increases `COMPONENT_STARTUP_TIMEOUT` to 5 seconds for `MiniSpeakerComponent` and `MiniAnimationActuator` to allow SICConnector to wait a bit longer.

3. Removes the use of `Tool.run_py_pkg()` for installing and running SIC, as its output is very limited. Instead, we now install/run SIC directly using SSH after successfully installing SSH on a mini.
