### PR TITLE
Fix sic installation on Pepper and Nao

### DIFF
--- a/sic_framework/core/utils.py
+++ b/sic_framework/core/utils.py
@@ -36,15 +36,15 @@ import socket
 def ping_server(server, port, timeout=3):
     """ping server"""
     try:
-        print(f"attempting to connect to device at server: {server} and port: {port}")
+        print("attempting to connect to device at server: {} and port: {}".format(server, port))
         socket.setdefaulttimeout(timeout)
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect((server, port))
     except OSError as error:
-        print(f"ERROR: {error}")
+        print("ERROR: ".format(error))
         return False
     except Exception as e:
-        print(f"Encountered exception while trying to connect to device: {e}")
+        print("Encountered exception while trying to connect to device: ".format(e))
     else:
         s.close()
         return True

--- a/sic_framework/core/utils.py
+++ b/sic_framework/core/utils.py
@@ -36,15 +36,15 @@ import socket
 def ping_server(server, port, timeout=3):
     """ping server"""
     try:
-        print("attempting to connect to device at server: {} and port: {}".format(server, port))
+        # print("attempting to connect to device at server: {} and port: {}".format(server, port))
         socket.setdefaulttimeout(timeout)
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect((server, port))
     except OSError as error:
-        print("ERROR: ".format(error))
+        print("OSError when trying to connect to device: {}".format(error))
         return False
     except Exception as e:
-        print("Encountered exception while trying to connect to device: ".format(e))
+        print("Encountered exception while trying to connect to device: {}".format(e))
     else:
         s.close()
         return True

--- a/sic_framework/devices/device.py
+++ b/sic_framework/devices/device.py
@@ -50,32 +50,34 @@ class SICLibrary(object):
         # download the binary first if necessary, as is the case with Pepper
         if self.download_cmd:
             stdin, stdout, stderr = ssh.exec_command(
-                "cd {} && {}".format(self.lib_path, self.download_cmd)
+                """cd {} && {} && echo "EXIT STATUS: $?" """.format(self.lib_path, self.download_cmd)
             )
+
+            output = "".join(stdout.readlines())
+            if "EXIT STATUS: 0" not in output:
+                err = "".join(stderr.readlines())
+                self.logger.error("Command: cd {} && {} \n Gave error:".format(self.lib_path, self.download_cmd))
+                self.logger.error(err)
+                raise RuntimeError(
+                    "Error while downloading library on remote device."
+                )
+
 
         # install the library
         stdin, stdout, stderr = ssh.exec_command(
             "cd {} && {}".format(self.lib_path, self.lib_install_cmd)
         )
 
-        # print a dot every line to indicate progress
-        while True:
-            line = stdout.readline()
-            # empty line means command is done
-            if len(line) == 0:
-                break
-
-            self.logger.info(".", end="")
-
-        err = stderr.readlines()
-        if len(err) > 0:
-            self.logger.error("".join(err))
-            self.logger.error("Command:", "cd {} && {}".format(self.lib_path, self.lib_install_cmd))
+        output = "".join(stdout.readlines())
+        if "Successfully installed" not in output:
+            err = "".join(stderr.readlines())
+            self.logger.error("Command: cd {} && {} \n Gave error:".format(self.lib_path, self.lib_install_cmd))
+            self.logger.error(err)
             raise RuntimeError(
                 "Error while installing library on remote device. Please consult manual installation instructions."
             )
         else:
-            self.logger.info(" done.")
+            self.logger.info("Successfully installed {} package".format(self.name))
 
 
 def exclude_pyc(tarinfo):

--- a/sic_framework/devices/device.py
+++ b/sic_framework/devices/device.py
@@ -45,7 +45,7 @@ class SICLibrary(object):
         """
         Download and install this Python library on a remote device
         """
-        self.logger.info("Installing {} on remote device ".format(self.name), end="")
+        self.logger.info("Installing {} on remote device ".format(self.name))
 
         # download the binary first if necessary, as is the case with Pepper
         if self.download_cmd:

--- a/sic_framework/devices/device.py
+++ b/sic_framework/devices/device.py
@@ -53,15 +53,6 @@ class SICLibrary(object):
                 "cd {} && {}".format(self.lib_path, self.download_cmd)
             )
 
-            # check to make sure download went smoothly
-            err = stderr.readlines()
-            if len(err) > 0:
-                self.logger.error("Command:", "cd {} && {} \n Gave error:".format(self.lib_path, self.download_cmd))
-                self.logger.error("".join(err))
-                raise RuntimeError(
-                    "Error while downloading library on remote device."
-                )
-
         # install the library
         stdin, stdout, stderr = ssh.exec_command(
             "cd {} && {}".format(self.lib_path, self.lib_install_cmd)

--- a/sic_framework/devices/nao.py
+++ b/sic_framework/devices/nao.py
@@ -46,7 +46,7 @@ class Nao(Naoqi):
                     if pip list | grep -w 'social-interaction-cloud' > /dev/null 2>&1 ; then
                         echo "SIC already installed";
                         # upgrade the social-interaction-cloud package
-                        # pip install --upgrade social-interaction-cloud --no-deps
+                        pip install --upgrade social-interaction-cloud --no-deps
                     else
                         echo "SIC is not installed";
                     fi;

--- a/sic_framework/devices/pepper.py
+++ b/sic_framework/devices/pepper.py
@@ -127,10 +127,11 @@ class Pepper(Naoqi):
         """
         _, stdout, stderr = self.ssh_command(
             """
+                    rm -rf /home/nao/framework;
                     if [ -d /home/nao/sic_framework_2 ]; then
                         rm -rf /home/nao/sic_framework_2;
                     fi;
-                    
+
                     mkdir /home/nao/sic_framework_2;
                     cd /home/nao/sic_framework_2;
                     curl -L -o sic_repo.zip https://github.com/Social-AI-VU/social-interaction-cloud/archive/refs/heads/main.zip;

--- a/sic_framework/devices/pepper.py
+++ b/sic_framework/devices/pepper.py
@@ -64,6 +64,7 @@ class Pepper(Naoqi):
             passwords=["pepper", "nao"],
             # device path is where this script is located on the actual Pepper machine
             device_path="/home/nao/sic_framework_2/social-interaction-cloud-main/sic_framework/devices",
+            test_device_path="/home/nao/sic_in_test/social-interaction-cloud/sic_framework/devices",
             **kwargs
         )
 


### PR DESCRIPTION
---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
SIC cannot be installed or run successfully on either Nao or Pepper

## What is the new behavior?
This PR fixes the following minor bugs when installing SIC on a remote device (Pepper or Nao):

1. Replaces f-strings with .format() in utils.py as python2 doesn't support f-string formatting
2. Make sure the old SIC installation on Pepper is removed (the previous SIC was installed at /home/nao/framework, and its libraries were being linked when running the current pepper.py).
3. Fixes misuse of the end parameter in device.py—logging does not support `end` parameter like print() does.

## Other information
It is still quite tedious to debug what happened on a remote device. The current logging does not capture all the standard/error output from the device during SIC installation and execution. This issue should be addressed in another PR

