### PR TITLE
Add MiniMicrophoneSensor as SICSensor

### DIFF
--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -112,7 +112,8 @@ class Alphamini(SICDevice):
         # The ssh port for mini is 8022
         # ssh u0_a25@ip --p 8022
         Tool.run_py_pkg("sshd", robot_id=self.mini_id, debug=True)
-        Tool.run_py_pkg('echo "sshd" >> ~/.bashrc', robot_id=self.mini_id, debug=True)
+        # only add sshd to bashrc if it's not there
+        Tool.run_py_pkg("grep -q 'sshd' ~/.bashrc || echo 'sshd' >> ~/.bashrc", robot_id=self.mini_id, debug=True)
 
         # install ftp
         # The ftp port for mini is 8021

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -308,9 +308,8 @@ class Alphamini(SICDevice):
         except (socket.timeout, socket.error):
             return False
 
-
-# mini_component_list = [MiniMicrophoneSensor, MiniSpeakerComponent, MiniAnimationActuator]
-mini_component_list = [MiniSpeakerComponent, MiniAnimationActuator]
+mini_component_list = [MiniMicrophoneSensor, MiniSpeakerComponent, MiniAnimationActuator]
+# mini_component_list = [MiniSpeakerComponent, MiniAnimationActuator]
 
 
 if __name__ == '__main__':

--- a/sic_framework/devices/common_mini/mini_microphone.py
+++ b/sic_framework/devices/common_mini/mini_microphone.py
@@ -11,7 +11,7 @@ from sic_framework.core.message_python2 import AudioMessage
 from sic_framework.core.sensor_python2 import SICSensor
 
 class MiniMicrophoneSensor(SICSensor):
-    COMPONENT_STARTUP_TIMEOUT = 5
+    COMPONENT_STARTUP_TIMEOUT = 10
 
     def __init__(self, *args, **kwargs):
         super(MiniMicrophoneSensor, self).__init__(*args, **kwargs)

--- a/sic_framework/devices/common_mini/mini_microphone.py
+++ b/sic_framework/devices/common_mini/mini_microphone.py
@@ -11,6 +11,8 @@ from sic_framework.core.message_python2 import AudioMessage
 from sic_framework.core.sensor_python2 import SICSensor
 
 class MiniMicrophoneSensor(SICSensor):
+    COMPONENT_STARTUP_TIMEOUT = 5
+
     def __init__(self, *args, **kwargs):
         super(MiniMicrophoneSensor, self).__init__(*args, **kwargs)
 

--- a/sic_framework/devices/common_mini/mini_microphone.py
+++ b/sic_framework/devices/common_mini/mini_microphone.py
@@ -1,64 +1,127 @@
-# import pyaudio
+import socket
+import time
+import subprocess
+
+import numpy as np
+import pyaudio
 
 from sic_framework import SICComponentManager
 from sic_framework.core.connector import SICConnector
-from sic_framework.core.message_python2 import AudioMessage, SICConfMessage
+from sic_framework.core.message_python2 import AudioMessage
 from sic_framework.core.sensor_python2 import SICSensor
-from sic_framework.devices.common_mini.mini_connector import MiniConnector
-
-
-class MiniMicrophoneConf(SICConfMessage):
-    def __init__(self):
-        self.no_channels = 1
-        self.sample_rate = 44100
-
 
 class MiniMicrophoneSensor(SICSensor):
     def __init__(self, *args, **kwargs):
         super(MiniMicrophoneSensor, self).__init__(*args, **kwargs)
-        self.alphamini = MiniConnector()
-        self.alphamini.connect()
 
-        self.audio_buffer = None
+        # audio settings
+        self.sample_rate = 44000
+        self.channels = 2 # stereo
+        self.bytes_per_sample = 2  # 16-bit audio
+        self.frame_size = 1024
+        self.buffer_time_ms = 250  # buffer duration in ms
+        self.buffer_size = int(self.sample_rate * (self.buffer_time_ms / 1000) * self.channels * self.bytes_per_sample)
+        self.buffer_accumulator = b""
 
-        # self.device = pyaudio.PyAudio()
-        #
-        # # open stream using callback (3)
-        # self.stream = self.device.open(
+        # Set up TCP server socket
+        self.host = "0.0.0.0"
+        self.port = 5000
+        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.server_socket.bind((self.host, self.port))
+        self.server_socket.listen(1)
+        self.server_socket.settimeout(1.0)
+        self.client_conn = None
+        self.last_connection_time = time.time()
+
+        self.logger.info(f"Listening for connections on {self.host}:{self.port}...")
+
+        # Start android com.example.micarraytest app
+        self.logger.info("Checking if Android app is running...")
+        self.start_app("com.example.micarraytest", ".MainActivity")
+
+        # pyaudio setup for debug playback
+        # self.audio = pyaudio.PyAudio()
+        # self.stream = self.audio.open(
         #     format=pyaudio.paInt16,
-        #     channels=1,
-        #     rate=self.params.sample_rate,
-        #     input=True,
-        #     output=False,
+        #     channels=self.channels,
+        #     rate=self.sample_rate,
+        #     output=True
         # )
 
-    @staticmethod
-    def get_conf():
-        return MiniMicrophoneConf()
-
-    @staticmethod
-    def get_inputs():
-        return []
-
-    @staticmethod
-    def get_output():
-        return AudioMessage
+    def start_app(self, package_name, activity_name):
+        result = subprocess.run(
+            ["adb", "shell", "pidof", package_name],
+            capture_output=True, text=True
+        )
+        pid = result.stdout.strip()
+        if bool(pid):
+            print(f"[INFO] App '{package_name}' is already running.")
+        else:
+            print(f"[INFO] App '{package_name}' is NOT running. Starting it...")
+            subprocess.run([
+                "adb", "shell", "am", "start", "-n", f"{package_name}/{activity_name}"
+            ])
 
     def execute(self):
-        self.logger.debug("Reading audio")
-        # read 250ms chunks
-        # data = self.stream.read(int(self.params.sample_rate // 4))
-        # return AudioMessage(data, sample_rate=self.params.sample_rate)
+        try:
+            if not self.client_conn:
+                try:
+                    self.client_conn, addr = self.server_socket.accept()
+                    self.logger.info(f"Connected by {addr}")
+                except socket.timeout:
+                    self.logger.info("No client connected, sending silence while waiting...")
+                    # if can't connect to client for 5 seconds, restart app
+                    current_time = time.time()
+                    if current_time - self.last_connection_time > 5:
+                        self.logger.warning("Lost connection for 5 seconds, restarting app...")
+                        self.start_app("com.example.micarraytest", ".MainActivity")
+                        self.last_connection_time = current_time
+                    return AudioMessage(b"\x00", sample_rate=self.sample_rate)
+
+            # receive audio until buffer is full
+            while len(self.buffer_accumulator) < self.buffer_size:
+                try:
+                    chunk = self.client_conn.recv(self.frame_size)
+                    if not chunk:
+                        self.logger.error("Socket client disconnected")
+                        self.client_conn.close()
+                        self.client_conn = None
+                        self.last_connection_time = time.time()
+                        self.buffer_accumulator = b""
+                        return AudioMessage(b"\x00", sample_rate=self.sample_rate)
+                    self.buffer_accumulator += chunk
+                except socket.timeout:
+                    continue
+            # process buffer by converting stereo to mono as dialogflow only accepts mono audio
+            stereo_buffer = self.buffer_accumulator[:self.buffer_size]
+            stereo_np = np.frombuffer(stereo_buffer, dtype=np.int16)
+            mono_np = stereo_np.reshape(-1, 2).mean(axis=1).astype(np.int16)
+            mono_buffer = mono_np.tobytes()
+
+            # Debug playback
+            # self.stream.write(stereo_buffer, exception_on_underflow=False)
+
+            msg = AudioMessage(mono_buffer, sample_rate=self.sample_rate)
+            self.buffer_accumulator = self.buffer_accumulator[self.buffer_size:]
+
+            return msg
+
+        except socket.error as e:
+            self.logger.error(f"Socket error: {e}")
 
     def stop(self, *args):
         super(MiniMicrophoneSensor, self).stop(*args)
         self.logger.info("Stopped microphone")
-        # self.stream.close()
 
+        if self.client_conn:
+            self.client_conn.close()
+        self.server_socket.close()
+        # self.stream.close()
+        # self.audio.terminate()
 
 class MiniMicrophone(SICConnector):
     component_class = MiniMicrophoneSensor
-
 
 if __name__ == "__main__":
     SICComponentManager([MiniMicrophoneSensor])

--- a/sic_framework/devices/common_mini/mini_microphone.py
+++ b/sic_framework/devices/common_mini/mini_microphone.py
@@ -50,18 +50,24 @@ class MiniMicrophoneSensor(SICSensor):
         # )
 
     def start_app(self, package_name, activity_name):
-        result = subprocess.run(
-            ["adb", "shell", "pidof", package_name],
-            capture_output=True, text=True
-        )
-        pid = result.stdout.strip()
-        if bool(pid):
-            print(f"[INFO] App '{package_name}' is already running.")
-        else:
-            print(f"[INFO] App '{package_name}' is NOT running. Starting it...")
-            subprocess.run([
-                "adb", "shell", "am", "start", "-n", f"{package_name}/{activity_name}"
-            ])
+        # can't find a way to check if an app is running on Android
+        # so we just try to start it anyway
+        subprocess.run([
+            "am", "start", "-n", f"{package_name}/{activity_name}"
+        ])
+        # this is the part if the file is running on a local machine
+        # result = subprocess.run(
+        #     ["adb", "shell", "pidof", package_name],
+        #     capture_output=True, text=True
+        # )
+        # pid = result.stdout.strip()
+        # if bool(pid):
+        #     print(f"[INFO] App '{package_name}' is already running.")
+        # else:
+        #     print(f"[INFO] App '{package_name}' is NOT running. Starting it...")
+        #     subprocess.run([
+        #         "adb", "shell", "am", "start", "-n", f"{package_name}/{activity_name}"
+        #     ])
 
     def execute(self):
         try:

--- a/sic_framework/devices/common_mini/mini_microphone.py
+++ b/sic_framework/devices/common_mini/mini_microphone.py
@@ -16,6 +16,8 @@ class MiniMicrophoneSensor(SICSensor):
     A SICSensor component that acts as a TCP server to receive raw audio data
     from the external Android micarraytest application (https://github.com/Social-AI-VU/alphamini_android),
     and streams it as mono audio messages for downstream processing (e.g., Dialogflow or other ASR systems).
+    At the time of writing, this component is running on the AlphaMini robot to stay consistent with the current structure.
+    If performance limitations or lag become more significant in the future, consider running it locally.
 
     This component:
     - Listens on a specified TCP port for incoming stereo audio data.


### PR DESCRIPTION
Issue number: resolves #39

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
Currently, there is no MicrophoneSensor that captures mic data on the AlphaMini robot as it does on Nao or Pepper, since the default system-level Termux installed from the manufacturer does not have permission to access the microphone. And, uninstalling the system-level app is not possible, as the AlphaMini is not a rooted device.

## What is the new behavior?
The hacky workaround is to create an app based on the [Demo for acquiring original audio data of the microphone](https://docs.ubtrobot.com/alphamini/#/en-us/resources/DOWNLOAD-RESOURCES?id=_13-demo-for-acquiring-original-audio-data-of-microphone) provided by the AlphaMini manufacturer. This app streams raw mic audio over TCP continuously and attempts to reconnect if the connection fails. The actual implementation can be found here: [alphamini_android](https://github.com/Social-AI-VU/alphamini_android).

The TCP server is created on the MiniMicrophoneSensor side. This component creates a TCP socket,  starts the android app, buffers the received audio, converts it from stereo to mono (as most ASR systems—like Google Dialogflow—expect mono-channel audio), and wraps it as a SIC AudioMessage.

## Other information
The MicrophoneSensor could actually run on a local laptop, as it essentially just opens a TCP server and receives audio. However, to stay consistent with the current structure, we are keeping everything on-device for now. That said, be aware of potential performance limitations and lag — we can always move it to the local desktop later if needed. Also, the TCP server IP is currently hardcoded on the Android side. This should be fixed by dynamically retrieving the IP that the robot is running on.