### PR TITLE
Fix non-homogeneous time sequences in NaoqiMotionRecorderActuator

### DIFF
--- a/sic_framework/devices/common_naoqi/naoqi_motion_recorder.py
+++ b/sic_framework/devices/common_naoqi/naoqi_motion_recorder.py
@@ -89,6 +89,7 @@ class PlayRecording(SICRequest):
             self.motion_recording_message.recorded_times = recorded_times.tolist()
 
 
+
 class NaoqiMotionRecorderConf(SICConfMessage):
     def __init__(
         self,
@@ -230,8 +231,7 @@ class NaoqiMotionRecorderActuator(SICActuator, NaoqiMotionTools):
         times = message.recorded_times
 
         if self.params.use_interpolation:
-            times = np.array(times) + self.params.setup_time
-            times = times.tolist()
+            times = [(np.array(t) + self.params.setup_time).tolist() for t in times]
 
             self.motion.angleInterpolation(
                 joints, angles, times, True

--- a/sic_framework/devices/common_naoqi/pepper_top_tactile_sensor.py
+++ b/sic_framework/devices/common_naoqi/pepper_top_tactile_sensor.py
@@ -18,7 +18,7 @@ class PepperTactileSensorMessage(SICMessage):
 
 class PepperTopTactileSensor(SICComponent):
     """
-    NaoqiButtonSensor is a sensor that reads the robot's physical button and touch values from the ALMemory module.
+    PepperTopTactileSensor is a sensor that reads the robot's physical button and touch values from the ALMemory module.
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION



<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
The interpolation does not work when time sequences have different lengths between joints, e.g., `KneePitch": {"angles": [28, 94, 80], "times": [48, 112, 156]}, "LElbowRoll": {"angles": [-1428, -623, -737, -1041, -1112], "times": [40, 76, 104, 148, 188]}` (generated from the motion JSON file by the `Choregraphe`, instead of recordings from SIC V2). This results in non-homogeneous time sequences, causing a ragged array error when trying to convert the entire times list into a numpy array using: np.array(times)

## What is the new behavior?
The issue was resolved by applying the `setup_time` offset individually to each joint’s time sequence, rather than converting the entire times list into a numpy array. This allows the offset to be added to variable-length time sequences.


