### PR TITLE
 Fix alphamini import error: move pkg_resources import inside function in pepper.py

### DIFF
--- a/sic_framework/devices/pepper.py
+++ b/sic_framework/devices/pepper.py
@@ -4,8 +4,6 @@ import argparse
 import os
 import subprocess
 
-from pkg_resources import DistributionNotFound, get_distribution
-
 from sic_framework.core.component_manager_python2 import SICComponentManager
 from sic_framework.devices.common_naoqi.naoqi_camera import (
     DepthPepperCamera,
@@ -120,6 +118,8 @@ class Pepper(Naoqi):
 
             # this command should get the version of SIC currently installed on the local machine, on all OSes including Windows
             try:
+                from pkg_resources import DistributionNotFound, get_distribution
+
                 cur_version = get_distribution("social-interaction-cloud").version
             except DistributionNotFound:
                 self.logger.error(


### PR DESCRIPTION

## What is the current behavior?
The nao/pepper package-level imports in devices/__init__.py will break devices/alphamini.py because pkg_resources requires setuptools. However, the dependencies for alphamini are installed manually, which means they are not installed via `install_requires` because the --no-deps flag is passed to avoid unnecessary installations like `opencv-python`.

## What is the new behavior?
For a quick fix, we moved the `pkg_resources` import inside a function in `pepper.py` to avoid the dependency at the module level.


## Other information

We should consider using absolute imports (e.g., from sic_framework.devices.nao import Nao) and remove importing the nao and pepper classes in `devices/__init__.py` to avoid loading unnecessary dependencies between devices. Although this reduces the simplicity of imports for users, it results in a cleaner design. We also need to clean up `install_requires` in `setup.py` to separate the absolute core dependencies from device-dependent/demo-dependent ones—for example, `opencv-python` is quite heavy and unnecessary if you are not running any camera demos.