### PR TITLE
Allow rolling back to a specific SIC version on devices

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ requirements = [
     "pyspacemouse",
     "redis",
     "scp",
-    "setuptools",
     "six",
 ]
 

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -7,23 +7,60 @@ import time
 import mini.mini_sdk as MiniSdk
 import mini.pkg_tool as Tool
 
-from sic_framework.core import utils
 from sic_framework import SICComponentManager
-from sic_framework.core.utils import MAGIC_STARTED_COMPONENT_MANAGER_TEXT
-from sic_framework.devices.common_mini.mini_animation import MiniAnimation, MiniAnimationActuator
-from sic_framework.devices.common_mini.mini_microphone import MiniMicrophone, MiniMicrophoneSensor
-from sic_framework.devices.common_mini.mini_speaker import MiniSpeaker, MiniSpeakerComponent
-from sic_framework.devices.device import SICDevice
+from sic_framework.core import utils
 from sic_framework.core.message_python2 import SICPingRequest, SICPongMessage
-
+from sic_framework.core.utils import MAGIC_STARTED_COMPONENT_MANAGER_TEXT
+from sic_framework.devices.common_mini.mini_animation import (
+    MiniAnimation,
+    MiniAnimationActuator,
+)
+from sic_framework.devices.common_mini.mini_microphone import (
+    MiniMicrophone,
+    MiniMicrophoneSensor,
+)
+from sic_framework.devices.common_mini.mini_speaker import (
+    MiniSpeaker,
+    MiniSpeakerComponent,
+)
+from sic_framework.devices.device import SICDevice
 
 
 class Alphamini(SICDevice):
-    def __init__(self, ip, mini_id, mini_password, redis_ip, username="u0_a25", port=8022, mic_conf=None, speaker_conf=None, dev_test=False, test_repo=None, bypass_install=False):
+    def __init__(
+        self,
+        ip,
+        mini_id,
+        mini_password,
+        redis_ip,
+        username="u0_a25",
+        port=8022,
+        mic_conf=None,
+        speaker_conf=None,
+        dev_test=False,
+        test_repo=None,
+        bypass_install=False,
+        sic_version=None,
+    ):
+        """
+        Initialize the Alphamini device.
+        :param ip: IP address of the Alphamini
+        :param mini_id: The last 5 digits of the Alphamini's serial number
+        :param mini_password: The password for the Alphamini
+        :param redis_ip: The IP address of the Redis server
+        :param username: The username for SSH (default: u0_a25)
+        :param port: The SSH port (default: 8022)
+        :param mic_conf: Configuration for the microphone
+        :param speaker_conf: Configuration for the speaker
+        :param dev_test: If True, use the test environment (default: False)
+        :param test_repo: Path to the test repository (default: None)
+        :param bypass_install: If True, skip the installation of SIC (default: False)
+        :param sic_version: Version of SIC to install on the Alphamini (default: None,which uses the same version as your local environment.
+
+        """
         self.mini_id = mini_id
         self.mini_password = mini_password
         self.redis_ip = redis_ip
-        self.venv = True
         self.dev_test = dev_test
         self.bypass_install = bypass_install
         self.test_repo = test_repo
@@ -41,10 +78,16 @@ class Alphamini(SICDevice):
             self.install_ssh()
 
         # only after ssh is available, we can initialize the SICDevice
-        super().__init__(ip=ip, username=username, passwords=mini_password, port=port)
+        super().__init__(
+            ip=ip,
+            username=username,
+            passwords=mini_password,
+            port=port,
+            sic_version=sic_version,
+        )
+        self.logger.info(f"SIC version on your local machine: {self.sic_version}")
         self.configs[MiniMicrophone] = mic_conf
         self.configs[MiniSpeaker] = speaker_conf
-
 
         if self.dev_test:
             self.create_test_environment()
@@ -61,7 +104,7 @@ class Alphamini(SICDevice):
     @property
     def mic(self):
         return self._get_connector(MiniMicrophone)
-    
+
     @property
     def speaker(self):
         return self._get_connector(MiniSpeaker)
@@ -72,67 +115,92 @@ class Alphamini(SICDevice):
 
     def install_ssh(self):
         # Updating the package manager
-        cmd_source_main = ("echo 'deb https://packages.termux.dev/apt/termux-main stable main' > "
-                           "/data/data/com.termux/files/usr/etc/apt/sources.list")
-        cmd_source_game = ("echo 'deb https://packages.termux.dev/apt/termux-games games stable' > "
-                           "/data/data/com.termux/files/usr/etc/apt/sources.list.d/game.list")
-        cmd_source_science = ("echo 'deb https://packages.termux.dev/apt/termux-science science stable' > "
-                              "/data/data/com.termux/files/usr/etc/apt/sources.list.d/science.list")
-        cmd_source_verify = "head /data/data/com.termux/files/usr/etc/apt/sources.list -n 5"
+        cmd_source_main = (
+            "echo 'deb https://packages.termux.dev/apt/termux-main stable main' > "
+            "/data/data/com.termux/files/usr/etc/apt/sources.list"
+        )
+        cmd_source_game = (
+            "echo 'deb https://packages.termux.dev/apt/termux-games games stable' > "
+            "/data/data/com.termux/files/usr/etc/apt/sources.list.d/game.list"
+        )
+        cmd_source_science = (
+            "echo 'deb https://packages.termux.dev/apt/termux-science science stable' > "
+            "/data/data/com.termux/files/usr/etc/apt/sources.list.d/science.list"
+        )
+        cmd_source_verify = (
+            "head /data/data/com.termux/files/usr/etc/apt/sources.list -n 5"
+        )
 
-        print('Updating the sources.list files...')
+        print("Updating the sources.list files...")
         Tool.run_py_pkg(cmd_source_main, robot_id=self.mini_id, debug=True)
         Tool.run_py_pkg(cmd_source_game, robot_id=self.mini_id, debug=True)
         Tool.run_py_pkg(cmd_source_science, robot_id=self.mini_id, debug=True)
 
-        print('Verifying that the source file has been updated')
+        print("Verifying that the source file has been updated")
         Tool.run_py_pkg(cmd_source_verify, robot_id=self.mini_id, debug=True)
 
-        print('Update the package manager...')
+        print("Update the package manager...")
         Tool.run_py_pkg("apt update && apt clean", robot_id=self.mini_id, debug=True)
 
         # this is necessary otherwise the system pkgs that later `apt` (precisely the https method under `apt`) will link to the old libssl.so.1.1, while
         # apt install -y openssl will install the new libssl.so.3
         # and throw error like "library "libssl.so.1.1" not found"
-        print('Upgrade the package manager...')
+        print("Upgrade the package manager...")
         # this will prompt the interactive openssl.cnf (Y/I/N/O/D/Z) [default=N] and hang, so pipe 'N' to it to avoid the prompt
         Tool.run_py_pkg("echo 'N' | apt upgrade -y", robot_id=self.mini_id, debug=True)
         Tool.run_py_pkg("echo 'N' | apt upgrade -y", robot_id=self.mini_id, debug=True)
         Tool.run_py_pkg("echo 'N' | apt upgrade -y", robot_id=self.mini_id, debug=True)
         Tool.run_py_pkg("echo 'N' | apt upgrade -y", robot_id=self.mini_id, debug=True)
 
-        print('Installing ssh...')
+        print("Installing ssh...")
         # Install openssh
-        Tool.run_py_pkg("echo 'N' | apt install -y openssh", robot_id=self.mini_id, debug=True)
+        Tool.run_py_pkg(
+            "echo 'N' | apt install -y openssh", robot_id=self.mini_id, debug=True
+        )
 
         # this is necessary for running ssh-keygen -A, otherwise it will throw CANNOT LINK EXECUTABLE "ssh-keygen": library "libcrypto.so.3" not found
-        Tool.run_py_pkg("echo 'N' | apt install -y openssl", robot_id=self.mini_id, debug=True)
+        Tool.run_py_pkg(
+            "echo 'N' | apt install -y openssl", robot_id=self.mini_id, debug=True
+        )
 
         # Set missing host keys
         Tool.run_py_pkg("ssh-keygen -A", robot_id=self.mini_id, debug=True)
 
         # Set password
-        Tool.run_py_pkg(f'echo -e "{self.mini_password}\n{self.mini_password}" | passwd',
-                        robot_id=self.mini_id, debug=True)
+        Tool.run_py_pkg(
+            f'echo -e "{self.mini_password}\n{self.mini_password}" | passwd',
+            robot_id=self.mini_id,
+            debug=True,
+        )
 
         # Start ssh and ftp-server
         # The ssh port for mini is 8022
         # ssh u0_a25@ip --p 8022
         Tool.run_py_pkg("sshd", robot_id=self.mini_id, debug=True)
         # only add sshd to bashrc if it's not there
-        Tool.run_py_pkg("grep -q 'sshd' ~/.bashrc || echo 'sshd' >> ~/.bashrc", robot_id=self.mini_id, debug=True)
+        Tool.run_py_pkg(
+            "grep -q 'sshd' ~/.bashrc || echo 'sshd' >> ~/.bashrc",
+            robot_id=self.mini_id,
+            debug=True,
+        )
 
         # install ftp
         # The ftp port for mini is 8021
-        Tool.run_py_pkg("pkg install -y busybox termux-services", robot_id=self.mini_id, debug=True)
-        Tool.run_py_pkg("source $PREFIX/etc/profile.d/start-services.sh", robot_id=self.mini_id, debug=True)
+        Tool.run_py_pkg(
+            "pkg install -y busybox termux-services", robot_id=self.mini_id, debug=True
+        )
+        Tool.run_py_pkg(
+            "source $PREFIX/etc/profile.d/start-services.sh",
+            robot_id=self.mini_id,
+            debug=True,
+        )
         time.sleep(10)
         Tool.run_py_pkg("sv-enable ftpd", robot_id=self.mini_id, debug=True)
         Tool.run_py_pkg("sv up ftpd", robot_id=self.mini_id, debug=True)
 
         print("The alphamini's ip-address is: ")
         Tool.run_py_pkg("ifconfig", robot_id=self.mini_id, debug=True)
-        print('Connect to alphamini with: ssh u0_a25@<ip> -p 8022')
+        print("Connect to alphamini with: ssh u0_a25@<ip> -p 8022")
 
     def check_sic_install(self):
         """
@@ -148,9 +216,11 @@ class Alphamini(SICDevice):
                         source ~/.venv_sic/bin/activate;
 
                         # upgrade the social-interaction-cloud package
-                        pip install --upgrade social-interaction-cloud --no-deps
+                        pip install --upgrade social-interaction-cloud=={version} --no-deps
                     fi;
-                    """
+                    """.format(
+                version=self.sic_version
+            )
         )
 
         output = stdout.read().decode()
@@ -195,10 +265,12 @@ class Alphamini(SICDevice):
                 source ~/.venv_sic/bin/activate;
 
                 # install required packages and perform a clean sic installation
-                pip install social-interaction-cloud --no-deps;
+                pip install social-interaction-cloud=={version} --no-deps;
                 pip install redis six pyaudio alphamini websockets==13.1 protobuf==3.20.3
 
-                """
+                """.format(
+                version=self.sic_version
+            )
         )
 
         output = stdout.read().decode()
@@ -228,7 +300,7 @@ class Alphamini(SICDevice):
         - if test_venv exists and no repo is passed in (self.test_repo), return True (no need to do anything)
         - if test_venv exists but a new repo has been passed in:
             1. uninstall old version of social-interaction-cloud on Alphamini
-            2. zip the provided repo 
+            2. zip the provided repo
             3. scp zip file over to alphamini, to 'sic_to_test' folder
             4. unzip repo and install
         - if test_venv does not exist:
@@ -283,25 +355,24 @@ class Alphamini(SICDevice):
 
             # get the basename of the repo
             repo_name = os.path.basename(self.test_repo)
-            
+
             # create the sic_in_test folder on Mini
             _, stdout, _, exit_status = self.ssh_command(
                 """
                 cd ~;
                 rm -rf sic_in_test;
                 mkdir sic_in_test;
-                """.format(repo_name=repo_name)
-            )    
+                """.format(
+                    repo_name=repo_name
+                )
+            )
 
             self.logger.info("Transferring zip file over to Mini")
 
             # scp transfer file over
             with self.SCPClient(self.ssh.get_transport()) as scp:
-                scp.put(
-                    zipped_path,
-                    "/data/data/com.termux/files/home/sic_in_test/"
-                )
-            
+                scp.put(zipped_path, "/data/data/com.termux/files/home/sic_in_test/")
+
             _, stdout, _, exit_status = self.ssh_command(
                 """
                 source ~/.test_venv/bin/activate;
@@ -309,13 +380,14 @@ class Alphamini(SICDevice):
                 unzip {repo_name};
                 cd {repo_name};
                 pip install -e . --no-deps;
-                """.format(repo_name=repo_name)
+                """.format(
+                    repo_name=repo_name
+                )
             )
 
             # check to see if the repo was installed successfully
             if exit_status != 0:
                 raise RuntimeError("Failed to install social-interaction-cloud")
-
 
         # check to see if test environment already exists
         _, stdout, _, exit_status = self.ssh_command(
@@ -325,60 +397,83 @@ class Alphamini(SICDevice):
         )
 
         if exit_status == 0 and not self.test_repo:
-            self.logger.info("Test environment already created on Mini and no new dev repo provided... skipping test_venv setup")
+            self.logger.info(
+                "Test environment already created on Mini and no new dev repo provided... skipping test_venv setup"
+            )
             return True
         elif exit_status == 0 and self.test_repo:
-            self.logger.info("Test environment already created on Mini and new dev repo provided... uninstalling old repo and installing new one")
-            self.logger.warning("This process may take a minute or two... Please hold tight!")
+            self.logger.info(
+                "Test environment already created on Mini and new dev repo provided... uninstalling old repo and installing new one"
+            )
+            self.logger.warning(
+                "This process may take a minute or two... Please hold tight!"
+            )
             uninstall_old_repo()
             install_new_repo()
         elif exit_status == 1 and self.test_repo:
             # test environment not created, so create one
-            self.logger.info("Test environment not created on Mini and new dev repo provided... creating test environment and installing new repo")
-            self.logger.warning("This process may take a minute or two... Please hold tight!")
+            self.logger.info(
+                "Test environment not created on Mini and new dev repo provided... creating test environment and installing new repo"
+            )
+            self.logger.warning(
+                "This process may take a minute or two... Please hold tight!"
+            )
             init_test_venv()
             install_new_repo()
         elif exit_status == 1 and not self.test_repo:
-            self.logger.error("No test environment present on Mini and no new dev repo provided... raising RuntimeError")
+            self.logger.error(
+                "No test environment present on Mini and no new dev repo provided... raising RuntimeError"
+            )
             raise RuntimeError("Need to provide repo to create test environment")
         else:
-            self.logger.error("Activating test environment on Mini resulted in unknown exit status: {}".format(exit_status))
-            raise RuntimeError("Unknown error occurred while creating test environment on Mini")            
-
+            self.logger.error(
+                "Activating test environment on Mini resulted in unknown exit status: {}".format(
+                    exit_status
+                )
+            )
+            raise RuntimeError(
+                "Unknown error occurred while creating test environment on Mini"
+            )
 
     def run_sic(self):
         self.logger.info("Running sic on alphamini...")
 
-
         self.stop_cmd = """
             echo 'Killing all previous robot wrapper processes';
             pkill -f "python {alphamini_device}"
-        """.format(alphamini_device=self.device_path)
+        """.format(
+            alphamini_device=self.device_path
+        )
 
         # stop alphamini
         self.logger.info("Killing previously running SIC processes")
         self.ssh_command(self.stop_cmd)
         time.sleep(1)
 
-
         self.start_cmd = """
             python {alphamini_device} --redis_ip={redis_ip} --alphamini_id {mini_id};
         """.format(
-            alphamini_device= self.device_path, redis_ip=self.redis_ip, mini_id=self.mini_id
+            alphamini_device=self.device_path,
+            redis_ip=self.redis_ip,
+            mini_id=self.mini_id,
         )
-
 
         # if this is a dev test, we want to use the test environment instead.
         if self.dev_test:
             self.logger.debug("Using developer test environment...")
-            self.start_cmd = """
+            self.start_cmd = (
+                """
                 source .test_venv/bin/activate;
-            """ + self.start_cmd
+            """
+                + self.start_cmd
+            )
         else:
-            self.start_cmd = """
+            self.start_cmd = (
+                """
                 source .venv_sic/bin/activate;
-            """ + self.start_cmd            
-
+            """
+                + self.start_cmd
+            )
 
         self.logger.info("starting SIC on alphamini")
 
@@ -395,15 +490,20 @@ class Alphamini(SICDevice):
                     self.ip, SICPingRequest(), timeout=self._PING_TIMEOUT, block=True
                 )
                 if response == SICPongMessage():
-                    self.logger.info("ComponentManager on ip {} has started!".format(self.ip))
+                    self.logger.info(
+                        "ComponentManager on ip {} has started!".format(self.ip)
+                    )
                     break
             except TimeoutError:
-                self.logger.debug("ComponentManager on ip {} hasn't started yet... retrying ping {} more times".format(self.ip, ping_tries - 1 - i))
+                self.logger.debug(
+                    "ComponentManager on ip {} hasn't started yet... retrying ping {} more times".format(
+                        self.ip, ping_tries - 1 - i
+                    )
+                )
         else:
             raise RuntimeError(
                 "Could not start SIC on remote device\nSee sic.log for details"
             )
-        
 
     def __del__(self):
         if hasattr(self, "logfile"):
@@ -425,18 +525,26 @@ class Alphamini(SICDevice):
         except (socket.timeout, socket.error):
             return False
 
-mini_component_list = [MiniMicrophoneSensor, MiniSpeakerComponent, MiniAnimationActuator]
+
+mini_component_list = [
+    MiniMicrophoneSensor,
+    MiniSpeakerComponent,
+    MiniAnimationActuator,
+]
 # mini_component_list = [MiniSpeakerComponent, MiniAnimationActuator]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--redis_ip", type=str, required=True, help="IP address where Redis is running"
     )
     parser.add_argument(
-        "--alphamini_id", type=str, required=True, help="Provide the last 5 digits of the robot's serial number"
+        "--alphamini_id",
+        type=str,
+        required=True,
+        help="Provide the last 5 digits of the robot's serial number",
     )
     args = parser.parse_args()
 

--- a/sic_framework/devices/nao.py
+++ b/sic_framework/devices/nao.py
@@ -4,23 +4,42 @@ import argparse
 import os
 
 from sic_framework.core.component_manager_python2 import SICComponentManager
+from sic_framework.devices.common_naoqi.nao_motion_streamer import (
+    NaoqiMotionStreamer,
+    NaoqiMotionStreamerService,
+)
 from sic_framework.devices.naoqi_shared import *
-from sic_framework.devices.common_naoqi.nao_motion_streamer import NaoqiMotionStreamerService, NaoqiMotionStreamer
+
 
 class Nao(Naoqi):
     """
     Wrapper for NAO device to easily access its components (connectors)
     """
 
-    def __init__(self, ip, **kwargs):
+    def __init__(self, ip, sic_version=None, dev_test=False, test_repo=None, **kwargs):
+        """
+        Initialize the Nao device wrapper.
+
+        :param ip: The IP address of the NAO robot.
+        :type ip: str
+        :param sic_version: The version of the SIC framework to use. Default is None which uses the same version as your local environment.
+        :type sic_version: str or None, optional
+        :param dev_test: Whether to use the device in development/testing mode. Default is False.
+        :type dev_test: bool, optional
+        :param test_repo: Path to the test repository that you want zipped and installed on the Nao. Default is None.
+        :type test_repo: str or None, optional
+        """
         super(Nao, self).__init__(
             ip,
             robot_type="nao",
             venv=True,
+            device_path="/data/home/nao/.venv_sic/lib/python2.7/site-packages/sic_framework/devices",
+            sic_version=sic_version,
+            dev_test=dev_test,
+            test_device_path="/home/nao/sic_in_test/social-interaction-cloud/sic_framework/devices",
+            test_repo=test_repo,
             username="nao",
             passwords="nao",
-            device_path="/data/home/nao/.venv_sic/lib/python2.7/site-packages/sic_framework/devices",
-            test_device_path="/home/nao/sic_in_test/social-interaction-cloud/sic_framework/devices",
             **kwargs
         )
 
@@ -46,11 +65,13 @@ class Nao(Naoqi):
                     if pip list | grep -w 'social-interaction-cloud' > /dev/null 2>&1 ; then
                         echo "SIC already installed";
                         # upgrade the social-interaction-cloud package
-                        pip install --upgrade social-interaction-cloud --no-deps
+                        pip install --upgrade social-interaction-cloud=={version} --no-deps
                     else
                         echo "SIC is not installed";
                     fi;
-                    """
+                    """.format(
+                version=self.sic_version
+            )
         )
 
         output = stdout.read().decode()
@@ -78,13 +99,15 @@ class Nao(Naoqi):
                     ln -s /usr/lib/python2.7/site-packages/cv2.so ~/.venv_sic/lib/python2.7/site-packages/cv2.so;
 
                     # install required packages
-                    pip install social-interaction-cloud --no-deps;
+                    pip install social-interaction-cloud=={version} --no-deps;
                     pip install Pillow PyTurboJPEG numpy redis six;
                                         
                     if pip list | grep -w 'social-interaction-cloud' > /dev/null 2>&1; then
                         echo "SIC successfully installed";
                     fi;
-                    """
+                    """.format(
+                version=self.sic_version
+            )
         )
 
         output = stdout.read().decode()
@@ -96,7 +119,7 @@ class Nao(Naoqi):
                     error
                 )
             )
-        
+
     def create_test_environment(self):
         """
         Creates a test environment on the Nao
@@ -112,7 +135,7 @@ class Nao(Naoqi):
         - if test_venv exists and no repo is passed in (self.test_repo), return True (no need to do anything)
         - if test_venv exists but a new repo has been passed in:
             1. uninstall old version of social-interaction-cloud on Nao
-            2. zip the provided repo     
+            2. zip the provided repo
             3. scp zip file over to nao, to 'sic_to_test' folder
             4. unzip repo and install
         - if test_venv does not exist:
@@ -177,17 +200,33 @@ class Nao(Naoqi):
                 cd ~;
                 rm -rf sic_in_test;
                 mkdir sic_in_test;
-                """.format(repo_name=repo_name)
-            )            
+                """
+            )
 
             self.logger.info("Transferring zip file over to Nao")
 
-            # scp transfer file over
-            with self.SCPClient(self.ssh.get_transport()) as scp:
-                scp.put(
-                    zipped_path,
-                    "/home/nao/sic_in_test/"
+            def progress4_callback(filename, size, sent, peername):
+                print(
+                    "\r({}:{}) {} progress: {:.2f}%".format(
+                        peername[0],
+                        peername[1],
+                        filename.decode("utf-8"),
+                        (float(sent) / float(size)) * 100,
+                    ),
+                    end="",
                 )
+
+            # scp transfer file over
+            with self.SCPClient(
+                self.ssh.get_transport(), progress4=progress4_callback
+            ) as scp:
+                try:
+                    scp.put(zipped_path, "/home/nao/sic_in_test/")
+                except Exception as e:
+                    self.logger.error(
+                        "Error transferring zip file over to Pepper: {}".format(e)
+                    )
+                    raise e
 
             self.logger.info("Unzipping repo and installing on Nao")
             _, stdout, _, exit_status = self.ssh_command(
@@ -197,7 +236,9 @@ class Nao(Naoqi):
                 unzip {repo_name};
                 cd {repo_name};
                 pip install -e . --no-deps;
-                """.format(repo_name=repo_name)
+                """.format(
+                    repo_name=repo_name
+                )
             )
 
             # check to see if the repo was installed successfully
@@ -212,29 +253,48 @@ class Nao(Naoqi):
         )
 
         if exit_status == 0 and not self.test_repo:
-            self.logger.info("Test environment already created on Nao and no new dev repo provided... skipping test_venv setup")
+            self.logger.info(
+                "Test environment already created on Nao and no new dev repo provided... skipping test_venv setup"
+            )
             return True
         elif exit_status == 0 and self.test_repo:
-            self.logger.info("Test environment already created on Nao and new dev repo provided... uninstalling old repo and installing new one")
-            self.logger.warning("This process may take a minute or two... Please hold tight!")
+            self.logger.info(
+                "Test environment already created on Nao and new dev repo provided... uninstalling old repo and installing new one"
+            )
+            self.logger.warning(
+                "This process may take a minute or two... Please hold tight!"
+            )
             uninstall_old_repo()
             install_new_repo()
         elif exit_status == 1 and self.test_repo:
             # test environment not created, so create one
-            self.logger.info("Test environment not created on Nao and new dev repo provided... creating test environment and installing new repo")
-            self.logger.warning("This process may take a minute or two... Please hold tight!")
+            self.logger.info(
+                "Test environment not created on Nao and new dev repo provided... creating test environment and installing new repo"
+            )
+            self.logger.warning(
+                "This process may take a minute or two... Please hold tight!"
+            )
             init_test_venv()
             install_new_repo()
         elif exit_status == 1 and not self.test_repo:
-            self.logger.error("No test environment present on Nao and no new dev repo provided... raising RuntimeError")
+            self.logger.error(
+                "No test environment present on Nao and no new dev repo provided... raising RuntimeError"
+            )
             raise RuntimeError("Need to provide repo to create test environment")
         else:
-            self.logger.error("Activating test environment on Nao resulted in unknown exit status: {}".format(exit_status))
-            raise RuntimeError("Unknown error occurred while creating test environment on Nao")
-      
+            self.logger.error(
+                "Activating test environment on Nao resulted in unknown exit status: {}".format(
+                    exit_status
+                )
+            )
+            raise RuntimeError(
+                "Unknown error occurred while creating test environment on Nao"
+            )
+
     @property
     def motion_streaming(self):
-        return self._get_connector(NaoqiMotionStreamer) 
+        return self._get_connector(NaoqiMotionStreamer)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -249,8 +309,6 @@ if __name__ == "__main__":
     if args.redis_pass:
         os.environ["DB_PASS"] = args.redis_pass
 
-    nao_components = shared_naoqi_components + [
-        NaoqiMotionStreamerService
-    ]
+    nao_components = shared_naoqi_components + [NaoqiMotionStreamerService]
 
     SICComponentManager(nao_components)

--- a/sic_framework/devices/pepper.py
+++ b/sic_framework/devices/pepper.py
@@ -70,6 +70,7 @@ class Pepper(Naoqi):
     def __init__(
         self,
         ip,
+        sic_version=None,
         stereo_camera_conf=None,
         depth_camera_conf=None,
         pepper_motion_conf=None,
@@ -84,6 +85,7 @@ class Pepper(Naoqi):
             # device path is where this script is located on the actual Pepper machine
             device_path="/home/nao/sic_framework_2/social-interaction-cloud-main/sic_framework/devices",
             test_device_path="/home/nao/sic_in_test/social-interaction-cloud/sic_framework/devices",
+            sic_version=sic_version,
             **kwargs
         )
 
@@ -116,19 +118,6 @@ class Pepper(Naoqi):
         else:
             self.logger.info("SIC is already installed, checking versions")
 
-            # this command should get the version of SIC currently installed on the local machine, on all OSes including Windows
-            try:
-                from pkg_resources import DistributionNotFound, get_distribution
-
-                cur_version = get_distribution("social-interaction-cloud").version
-            except DistributionNotFound:
-                self.logger.error(
-                    "Failed to find the 'social-interaction-cloud' package locally. Ensure it is installed using pip."
-                )
-                raise RuntimeError(
-                    "Package 'social-interaction-cloud' is not installed locally. Please install it using pip."
-                )
-
             # get the version of SIC installed on Pepper
             pepper_version = ""
 
@@ -139,9 +128,10 @@ class Pepper(Naoqi):
                     break
 
             self.logger.info("SIC version on Pepper: {}".format(pepper_version))
-            self.logger.info("SIC local version: {}".format(cur_version))
+            # if you don't pass sic_version, it will grab your local version
+            self.logger.info("SIC local version: {}".format(self.sic_version))
 
-            if pepper_version == cur_version:
+            if pepper_version == self.sic_version:
                 self.logger.info("SIC already installed on Pepper and versions match")
                 return True
             else:
@@ -172,15 +162,18 @@ class Pepper(Naoqi):
 
                     mkdir /home/nao/sic_framework_2;
                     cd /home/nao/sic_framework_2;
-                    curl -L -o sic_repo.zip https://github.com/Social-AI-VU/social-interaction-cloud/archive/refs/heads/main.zip;
+                    curl -L -o sic_repo.zip https://github.com/Social-AI-VU/social-interaction-cloud/archive/refs/tags/v{version}.zip;
                     unzip sic_repo.zip;
-                    cd /home/nao/sic_framework_2/social-interaction-cloud-main;
+                    mv social-interaction-cloud-{version} social-interaction-cloud-main;
+                    cd social-interaction-cloud-main;
                     pip install --user -e . --no-deps;
                                         
                     if pip list | grep -w 'social-interaction-cloud' > /dev/null 2>&1 ; then
                         echo "SIC successfully installed"
                     fi;
-                    """
+                    """.format(
+                version=self.sic_version
+            )
         )
 
         if not "SIC successfully installed" in stdout.read().decode():

--- a/sic_framework/devices/pepper.py
+++ b/sic_framework/devices/pepper.py
@@ -136,7 +136,7 @@ class Pepper(Naoqi):
                 return True
             else:
                 self.logger.warning(
-                    "SIC is installed on Pepper but does not match the local version! Reinstalling SIC on Pepper"
+                    "SIC is installed on Pepper but does not match the local version or the version you passed! Reinstalling SIC on Pepper"
                 )
                 self.logger.warning(
                     "(Check to make sure you also have the latest version of SIC installed!)"


### PR DESCRIPTION
Issue number: resolves #60

---------

## What is the current behavior?
Currently, the SIC version on devices is automatically upgraded to the latest version from PyPI. While this plug-and-play behavior is convenient when the latest release is stable, SIC is still developing rapidly, so new releases can sometimes introduce bugs. Therefore, it is useful to have the option to roll back to a specific version.

## What is the new behavior?

The `sic_version` parameter is now exposed for `Nao` and `Alphamini` devices. If a specific version is provided, that version will be installed on the device. If nothing is passed, the default behavior is to use the same SIC version as the local environment. So the downside of this change is that the robots/devices will no longer upgrade to the latest SIC version automatically if no `sic_version` is passed, but will instead stay in sync with the SIC version currently running locally, which actually makes more sense.

