### PR TITLE
Fix weird spacemouse control behavior and add gripper support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ extras_require = {
     "franka": [
         "pyspacemouse",
         "scipy",
+        "numpy<2.0.0",  # numpy 2.0.0 is not compatible with panda_py
     ],
 }
 

--- a/sic_framework/devices/common_franka/franka_motion.py
+++ b/sic_framework/devices/common_franka/franka_motion.py
@@ -6,6 +6,8 @@ from sic_framework.core.utils import is_sic_instance
 
 import panda_py
 from panda_py import controllers
+from panda_py import libfranka
+
 
 import threading
 import time
@@ -31,22 +33,67 @@ class FrankaPose(SICMessage):
         self.position = position
         self.orientation = orientation
 
+
+class FrankaGripperGraspRequest(SICRequest):
+    """
+    A SICRequest to command the gripper to grasp an object with a force-controlled command.
+
+    see the api documentation for more details: https://jeanelsner.github.io/panda-py/panda_py.libfranka.html#panda_py.libfranka.Gripper.grasp
+
+    :param width: The distance between the fingers in meters. The width must be between 0.0 and 0.085 m.
+    :param speed: The speed of the gripper in meters per second. The speed must be between 0 and 0.1 m/s.
+    :param force: The gripping force in Newton. The force must be between 5 and 70 N.
+    :param epsilon_inner: The inner tolerance for the grasp width in meters.
+    :param epsilon_outer: The outer tolerance for the grasp width in meters.
+    """
+    def __init__(self, width, speed=0.1, force=5, epsilon_inner=0.005, epsilon_outer=0.005):
+        super().__init__()
+        self.width = width
+        self.speed = speed
+        self.force = force
+        self.epsilon_inner = epsilon_inner
+        self.epsilon_outer = epsilon_outer
+
+class FrankaGripperMoveRequest(SICRequest):
+    """
+    A SICRequest to command the gripper to move to a specific width.
+
+    see the api documentation for more details: https://jeanelsner.github.io/panda-py/panda_py.libfranka.html#panda_py.libfranka.Gripper.move
+
+    :param width: The distance between the fingers in meters. The width must be between 0.0 and 0.085 m.
+    :param speed: The speed of the gripper in meters per second. The speed must be between 0 and 0.1 m/s.
+    """
+    def __init__(self, width, speed=0.1):
+        super().__init__()
+        self.width = width
+        self.speed = speed
+
 # TODO maybe an actuator is not a correct name here
 class FrankaMotionActuator(SICActuator):
     def __init__(self, *args, **kwargs):
         super(FrankaMotionActuator, self).__init__(*args, **kwargs)
-        self.panda = panda_py.Panda("172.16.0.2")
+        hostname = "172.16.0.2"
+        self.panda = panda_py.Panda(hostname)
         # here we set the controller to Cartesian Impedance, which only requires position and orientation to control the end effector (EE)
         # see more details: https://jeanelsner.github.io/panda-py/panda_py.controllers.html#panda_py.controllers.CartesianImpedance.set_control
         self.ctrl = controllers.CartesianImpedance(filter_coeff=1.0)
         self.panda.start_controller(self.ctrl)
+
+        # gripper object
+        self.gripper = libfranka.Gripper(hostname)
+
         # for streaming thread
         self._streaming = False
         self._stream_thread = None
     # it's the EE pose we want to send to set_control
     @staticmethod
     def get_inputs():
-        return [FrankaPose]
+        return [
+            FrankaPose,
+            FrankaGripperGraspRequest,
+            FrankaGripperMoveRequest,
+            FrankaPoseRequest
+        ]
 
     # it's outputting the current EE pose from _start_streaming
     @staticmethod
@@ -70,6 +117,16 @@ class FrankaMotionActuator(SICActuator):
                     )
                     self._stream_thread.start()
             return self.get_pose()
+        if is_sic_instance(request, FrankaGripperGraspRequest):
+            self.logger.info("Grasping with width: {}, speed: {}, force: {}, epsilon_inner: {}, epsilon_outer: {}".format(
+                request.width, request.speed, request.force, request.epsilon_inner, request.epsilon_outer))
+
+            self.gripper.grasp(request.width, request.speed, request.force, request.epsilon_inner, request.epsilon_outer)
+        if is_sic_instance(request, FrankaGripperMoveRequest):
+            self.gripper.move(request.width, request.speed)
+
+        return SICMessage()
+
 
     def get_pose(self):
         # retrieve the current end-effector position and orientation in the robot base frame.

--- a/sic_framework/devices/franka.py
+++ b/sic_framework/devices/franka.py
@@ -24,6 +24,7 @@ def start_franka_components():
     """
     Initialize and run the Franka component manager
     """
+
     global franka_active
     manager = SICComponentManager(franka_component_list, client_id=utils.get_ip_adress(), auto_serve=False, name="Franka")
 
@@ -38,6 +39,7 @@ class Franka(SICDevice):
     Franka device interface that automatically starts the component manager
     in a background thread on first initialization.
     """
+
     def __init__(self, motion_conf=None):
         """
         Initialize the Franka device with the given motion configuration
@@ -59,6 +61,7 @@ class Franka(SICDevice):
         Get the Franka motion recorder connector.
         :return: The FrankaMotionRecorder connector.
         """
+
         return self._get_connector(FrankaMotionRecorder)
 
     @property
@@ -67,6 +70,7 @@ class Franka(SICDevice):
         Get the Franka motion connector.
         :return: The FrankaMotion connector.
         """
+
         return self._get_connector(FrankaMotion)
 
 


### PR DESCRIPTION
Issue number: resolves #70

---------


## What is the current behavior?
The spacemouse control was acting weirdly previously because the pose publishing frequency was too high, and the subscriber callback couldn’t keep up. This caused delays in processing within the callback, resulting in unexpected behavior.

Also, there was no gripper control.

## What is the new behavior?
Reduce the pose publishing frequency to 500 Hz.

Add `FrankaGripperGraspRequest` and `FrankaGripperMoveRequest` to handle gripper control requests. See more details about the parameters passed to `grasp()` and `move()` in the API and the tutorial:

[API documentation](https://jeanelsner.github.io/panda-py/panda_py.libfranka.html?utm_source=chatgpt.com#panda_py.libfranka.Gripper.grasp)

[Tutorial notebook](https://github.com/JeanElsner/panda-py/blob/main/examples/notebooks/tutorial.ipynb?utm_source=chatgpt.com)

Also, add a dependency requirement for using `panda-py`, as numpy 2.0.0 is not compatible. See a similar GitHub issue for details: https://github.com/JeanElsner/panda-py/issues/40



## Does this introduce a breaking change?

- [X] Yes
- [ ] No
