### PR TITLE
Added dependencies for compiling docs to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,11 @@ extras_require = {
         "scipy",
         "numpy<2.0.0",  # numpy 2.0.0 is not compatible with panda_py
     ],
+    "docs": [
+        "sphinx",
+        "sphinx-togglebutton",
+        "sphinx-rtd-theme",
+    ],
 }
 
 setup(


### PR DESCRIPTION
Issue number: resolves #79 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
No dependencies for compiling Sphinx docs in setup.py

## What is the new behavior?
Sphinx dependencies are now present, so you can easily install them with "pip install -e .[docs]"
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X ] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
