### PR TITLE
Streaming speakers for Naoqi devices

### DIFF
--- a/sic_framework/core/message_python2.py
+++ b/sic_framework/core/message_python2.py
@@ -480,12 +480,13 @@ class Audio(object):
     You can convert to and from .wav files using the built-in module https://docs.python.org/2/library/wave.html
     """
 
-    def __init__(self, waveform, sample_rate):
+    def __init__(self, waveform, sample_rate, is_stream=False):
         self.sample_rate = sample_rate
         assert isinstance(waveform, bytes) or isinstance(
             waveform, bytearray
         ), "Waveform must be a byte array"
         self.waveform = waveform
+        self.is_stream = is_stream
 
 
 class AudioMessage(Audio, SICMessage):


### PR DESCRIPTION
## What is the current behavior?
Before with Nao devices (see play_audio function), you must write the audio to disk first as a .wav file, then NAOqi loads and starts playing the file. Which introduced high latency and unnecessary IO operations. 

## What is the new behavior?
I've implemented a change to support streaming audio (for use cases such as real-time TTS interactive systems that need to “talk” as they generate audio, live audio streaming from another process such as an audiomixer etc. ) just tested it with one of our Pepper robots. The chunks should be PCM 16 bit stereo data with a maximum of 16384 frames (if SR is 16000, that means 1.024 seconds) and a minimum of 4096 frames (if SR is 16000, that means 0.256 seconds) for achieving the lowest latency possible. The change should not break original functionality of existing SIC applications.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
