### PR TITLE
Recover SSH daemon

### DIFF
--- a/docs/source/faq/comprehensive_faq.rst
+++ b/docs/source/faq/comprehensive_faq.rst
@@ -102,6 +102,38 @@ Cannot connect to robot from IDE terminal
       the issue is specifically related to VSCode's terminal permissions, not your network or robot configuration.
 
 
+AlphaMini SSH connection refused
+--------------------------------
+
+.. toggle::
+
+   **Problem:** ``ssh u0_a25@<mini-ip> -p 8022`` returns ``Connection refused``.
+
+   **Solution:**
+
+   On AlphaMini, this usually means ``sshd`` is down (not listening), even if OpenSSH is already installed.
+   Before reinstalling SSH packages, run the lightweight recovery helper:
+
+   .. code-block:: bash
+
+      python sic_applications/utils/alphamini_restart_ssh.py --mini-id <mini-id>
+
+   Then retry SSH:
+
+   .. code-block:: bash
+
+      ssh u0_a25@<mini-ip> -p 8022
+
+   To intentionally test recovery behavior, first stop ``sshd``:
+
+   .. code-block:: bash
+
+      python sic_applications/utils/alphamini_restart_ssh.py --mini-id <mini-id> --kill-sshd
+
+   Then run the helper again without ``--kill-sshd`` (or start an SIC app using ``Alphamini``)
+   and verify that SSH becomes available again.
+
+
 Windows WSL Connection Issues
 ------------------------------
 

--- a/docs/source/getting_started/getting_started_alphamini.rst
+++ b/docs/source/getting_started/getting_started_alphamini.rst
@@ -147,6 +147,34 @@ network, to avoid extra configuration and authentication issues.
    run shell commands.
 
 
+Troubleshooting SSH on Alphamini
+--------------------------------
+
+If SIC reports SSH on port ``8022`` as unavailable, that does **not** always
+mean OpenSSH must be reinstalled. A common failure mode is that ``sshd`` is
+installed but not currently running.
+
+Use the SIC helper script first:
+
+1. From the repository root, run:
+
+   .. code-block:: bash
+
+      python sic_applications/utils/alphamini_restart_ssh.py --mini-id <mini-id>
+
+   This sends a lightweight command via ``Tool.run_py_pkg``. In environments
+   where shell startup triggers ``sshd``, this restores SSH availability
+   without a full reinstall.
+
+2. Verify from your computer:
+
+   .. code-block:: bash
+
+      ssh u0_a25@<mini-ip> -p 8022
+
+If ``sshd`` is missing or restart fails, run any Alphamini demo and SSH will be reinstalled.
+
+
 Installing the Alphamini camera and microphone apps
 ---------------------------------------------------
 

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -113,9 +113,11 @@ class Alphamini(SICDeviceManager):
 
         MiniSdk.set_robot_type(MiniSdk.RobotType.EDU)
 
-        # Check if ssh is available
-        if not self._is_ssh_available(host=ip):
-            self.install_ssh()
+        # Check if ssh is available. If the port is closed, first try a light
+        # recovery by restarting sshd before falling back to full re-install.
+        if not self._is_ssh_available(host=ip, port=port):
+            if not self._try_recover_ssh_daemon(host=ip, port=port):
+                self.install_ssh()
 
         # only after ssh is available, we can initialize the SICDeviceManager
         super().__init__(
@@ -330,6 +332,38 @@ class Alphamini(SICDeviceManager):
     @property
     def camera(self):
         return self._get_connector(MiniCamera)
+
+    def _try_recover_ssh_daemon(self, host, port=8022):
+        print(
+            "SSH port {port} is unreachable on {host}. Attempting lightweight recovery before reinstall...".format(
+                port=port, host=host
+            )
+        )
+
+        # First, run a simple command through the py-pkg path. On some robots
+        # this is enough to trigger shell init that brings sshd back.
+        probe_command = "if echo sic_probe >/dev/null 2>&1; then exit 0; else exit 41; fi"
+        try:
+            Tool.run_py_pkg(probe_command, robot_id=self.mini_id, debug=True)
+            time.sleep(2)
+            if self._is_ssh_available(host=host, port=port):
+                print("SSH became available after lightweight run_py_pkg probe.")
+                return True
+        except Exception:
+            pass
+
+        # Retry once more before attempting explicit daemon restart.
+        try:
+            Tool.run_py_pkg(probe_command, robot_id=self.mini_id, debug=True)
+            time.sleep(2)
+            if self._is_ssh_available(host=host, port=port):
+                print("SSH became available after second run_py_pkg probe.")
+                return True
+        except Exception:
+            pass
+
+        # SSH is likely not installed or misconfigured. Fall back to full reinstall.
+        return False
 
     def install_ssh(self):
         # Updating the package manager


### PR DESCRIPTION
Issue number: resolves #139 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
When ``Alphamini`` initializes, it checks TCP reachability of SSH on port ``8022``.
If the port is closed, the code immediately runs the full ``install_ssh()`` pipeline.
This is slow and disruptive in cases where OpenSSH is already installed and only the
daemon is down (e.g., crashed, killed, or not started after reboot).

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- ``Alphamini`` now attempts lightweight SSH recovery before reinstalling:
  it runs a simple ``Tool.run_py_pkg`` probe (twice), rechecks port ``8022``,
  and only falls back to ``install_ssh()`` if recovery fails.
- Alphamini getting-started docs now include SSH troubleshooting that references:
  ``python sic_applications/utils/alphamini_restart_ssh.py --mini-id <mini-id>``.
- FAQ now includes an ``AlphaMini SSH connection refused`` entry with recovery
  and intentional kill/recovery validation commands.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- Manual validation performed:
  - Killing ``sshd`` drops active SSH sessions and causes ``Connection refused``.
  - Running the lightweight helper path restores SSH availability without full reinstall.
