### PR TITLE
143 feature tailscale

### DIFF
--- a/sic_framework/core/utils.py
+++ b/sic_framework/core/utils.py
@@ -26,6 +26,32 @@ def get_ip_adress():
     :return: The IP address of the device.
     :rtype: str
     """
+    use_tailscale = os.environ.get("USE_TAILSCALE", "").lower() in ("1", "true", "yes")
+
+    if use_tailscale:
+        import json
+        import subprocess
+
+        ts_socket = os.environ.get("TS_SOCKET")
+
+        for ts_cmd in ("tailscale", "./tailscale"):
+            try:
+                cmd = [ts_cmd]
+                if ts_socket:
+                    cmd += ["--socket", ts_socket]
+                cmd += ["status", "--json"]
+
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=5
+                )
+                if result.returncode == 0:
+                    data = json.loads(result.stdout)
+                    ips = data.get("Self", {}).get("TailscaleIPs", [])
+                    if ips:
+                        return ips[0]
+            except (FileNotFoundError, ValueError, KeyError, subprocess.TimeoutExpired):
+                continue
+
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(0)
     try:

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -564,9 +564,9 @@ class Alphamini(SICDeviceManager):
             if [ ! -x ~/tailscale/tailscale ]; then
                 pkg install -y wget socat
                 mkdir -p ~/tailscale && cd ~/tailscale
-                wget -q https://pkgs.tailscale.com/stable/tailscale_1.62.1_arm64.tgz
-                tar xzf tailscale_1.62.1_arm64.tgz --strip-components=1
-                rm -f tailscale_1.62.1_arm64.tgz
+                wget -q https://pkgs.tailscale.com/stable/tailscale_1.96.4_arm64.tgz
+                tar xzf tailscale_1.96.4_arm64.tgz --strip-components=1
+                rm -f tailscale_1.96.4_arm64.tgz
             fi
             mkdir -p ~/.tailscale_state
             if ! pgrep -f tailscaled > /dev/null 2>&1; then

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -134,11 +134,13 @@ class Alphamini(SICDeviceManager):
         self.configs[MiniSpeaker] = speaker_conf
         self.configs[MiniCamera] = camera_conf
 
-        # If Tailscale is requested or already on the robot, ensure it's set up
+        # If Tailscale is explicitly enabled (or already on the robot), ensure it's set up
+        use_tailscale = os.environ.get("USE_TAILSCALE", "").lower() in ("1", "true", "yes")
         _, stdout, _, _ = self.ssh_command(
             "[ -x ~/tailscale/tailscale ] && echo 'ts_yes' || echo 'ts_no'"
         )
-        if self.tailscale_authkey or "ts_yes" in stdout.read().decode():
+        ts_installed = "ts_yes" in stdout.read().decode()
+        if use_tailscale and (self.tailscale_authkey or ts_installed):
             self.install_tailscale()
             _, stdout, _, _ = self.ssh_command(
                 "~/tailscale/tailscale --socket ~/tailscale/tailscaled.sock ip -4"
@@ -559,6 +561,7 @@ class Alphamini(SICDeviceManager):
         """
         Install, start, and authenticate Tailscale in userspace mode on the robot.
         """
+        # Install binary if missing
         self.ssh_command(
             """
             if [ ! -x ~/tailscale/tailscale ]; then
@@ -569,14 +572,38 @@ class Alphamini(SICDeviceManager):
                 rm -f tailscale_1.96.4_arm64.tgz
             fi
             mkdir -p ~/.tailscale_state
-            if ! pgrep -f tailscaled > /dev/null 2>&1; then
-                cd ~/tailscale
-                nohup ./tailscaled --tun=userspace-networking --socks5-server=localhost:1055 \
-                    --statedir=$HOME/.tailscale_state > ~/tailscale/tailscaled.log 2>&1 &
-                sleep 2
-            fi
             """
         )
+
+        # Check if daemon is already running with the correct socket
+        _, stdout, _, _ = self.ssh_command(
+            "pgrep -f tailscaled > /dev/null 2>&1 && [ -S ~/tailscale/tailscaled.sock ] && echo ok"
+        )
+        daemon_running = "ok" in stdout.read().decode()
+
+        if not daemon_running:
+            self.ssh_command("pkill -f tailscaled || true; rm -f ~/tailscale/tailscaled.sock")
+            time.sleep(1)
+            # Start daemon in its own thread (same pattern as run_sic for SIC)
+            self.ssh_command(
+                "cd ~/tailscale && ./tailscaled --tun=userspace-networking "
+                "--socks5-server=localhost:1055 "
+                "--statedir=$HOME/.tailscale_state "
+                "--socket=$HOME/tailscale/tailscaled.sock "
+                "> ~/tailscale/tailscaled.log 2>&1",
+                create_thread=True, get_pty=False
+            )
+            # Wait up to 10s for socket to appear
+            for _ in range(10):
+                _, stdout, _, _ = self.ssh_command("[ -S ~/tailscale/tailscaled.sock ] && echo ok")
+                if "ok" in stdout.read().decode():
+                    break
+                time.sleep(1)
+            else:
+                raise DeviceInstallationError(
+                    "Tailscale daemon failed to start. Check ~/tailscale/tailscaled.log"
+                )
+
         # Check auth state
         _, stdout, _, _ = self.ssh_command(
             "~/tailscale/tailscale --socket ~/tailscale/tailscaled.sock status >/dev/null 2>&1 && echo ok"
@@ -590,11 +617,12 @@ class Alphamini(SICDeviceManager):
                     "Generate one at https://login.tailscale.com/admin/settings/keys"
                 )
             self.logger.info("Authenticating Tailscale with auth key...")
-            self.ssh_command(
-                "~/tailscale/tailscale --socket ~/tailscale/tailscaled.sock up --authkey {key}".format(
+            _, stdout, _, _ = self.ssh_command(
+                "~/tailscale/tailscale --socket ~/tailscale/tailscaled.sock up --authkey {key} 2>&1".format(
                     key=self.tailscale_authkey
                 )
             )
+            self.logger.info("tailscale up output: {}".format(stdout.read().decode()))
             # Verify auth succeeded
             _, stdout, _, _ = self.ssh_command(
                 "~/tailscale/tailscale --socket ~/tailscale/tailscaled.sock status >/dev/null 2>&1 && echo ok"
@@ -608,19 +636,6 @@ class Alphamini(SICDeviceManager):
             self.logger.info("Tailscale authenticated successfully")
         else:
             self.logger.info("Tailscale already authenticated")
-
-        # Ensure auto-start on future boots
-        self.ssh_command(
-            """
-            grep -q 'tailscaled' ~/.bashrc || cat >> ~/.bashrc << 'EOF'
-if ! pgrep -f tailscaled > /dev/null 2>&1; then
-    cd ~/tailscale && nohup ./tailscaled --tun=userspace-networking \
-        --socks5-server=localhost:1055 --statedir=$HOME/.tailscale_state \
-        > ~/tailscale/tailscaled.log 2>&1 & sleep 1
-fi
-EOF
-            """
-        )
 
     def _configure_tailscale_env(self, venv_name):
         """Add Tailscale env vars to a venv's activate script (no-op if venv missing)."""
@@ -644,7 +659,9 @@ EOF
             return  # Not a Tailscale IP, skip
         self.ssh_command(
             """
-            if [ -x ~/tailscale/tailscale ] && ! ss -tlnp 2>/dev/null | grep -q ':6379 '; then
+            if [ -x ~/tailscale/tailscale ]; then
+                pkill -f socat || true
+                sleep 1
                 nohup socat TCP4-LISTEN:6379,bind=127.0.0.1,reuseaddr,fork \
                     SOCKS5:127.0.0.1:{ts_host_ip}:6379,socksport=1055 > ~/socat_redis.log 2>&1 &
             fi

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -76,6 +76,7 @@ class Alphamini(SICDeviceManager):
         test_repo=None,
         bypass_install=False,
         sic_version=None,
+        tailscale_authkey=None,
     ):
         """
         Initialize the Alphamini device.
@@ -105,6 +106,7 @@ class Alphamini(SICDeviceManager):
         self._sdk_animation_futures = []
         self._sdk_loop = None
         self._sdk_loop_thread = None
+        self.tailscale_authkey = tailscale_authkey
 
         # Module path for the Alphamini device script. We invoke it via
         # "python -m sic_framework.devices.alphamini" on the robot, so we do not
@@ -131,6 +133,19 @@ class Alphamini(SICDeviceManager):
         self.configs[MiniMicrophone] = mic_conf
         self.configs[MiniSpeaker] = speaker_conf
         self.configs[MiniCamera] = camera_conf
+
+        # If Tailscale is requested or already on the robot, ensure it's set up
+        _, stdout, _, _ = self.ssh_command(
+            "[ -x ~/tailscale/tailscale ] && echo 'ts_yes' || echo 'ts_no'"
+        )
+        if self.tailscale_authkey or "ts_yes" in stdout.read().decode():
+            self.install_tailscale()
+            _, stdout, _, _ = self.ssh_command(
+                "~/tailscale/tailscale --socket ~/tailscale/tailscaled.sock ip -4"
+            )
+            ts_ip = stdout.read().decode().strip()
+            if ts_ip:
+                self.device_ip = ts_ip
 
         if self.dev_test:
             self.create_test_environment()
@@ -540,6 +555,102 @@ class Alphamini(SICDeviceManager):
         else:
             self.logger.info("SIC successfully installed")
 
+    def install_tailscale(self):
+        """
+        Install, start, and authenticate Tailscale in userspace mode on the robot.
+        """
+        self.ssh_command(
+            """
+            if [ ! -x ~/tailscale/tailscale ]; then
+                pkg install -y wget socat
+                mkdir -p ~/tailscale && cd ~/tailscale
+                wget -q https://pkgs.tailscale.com/stable/tailscale_1.62.1_arm64.tgz
+                tar xzf tailscale_1.62.1_arm64.tgz --strip-components=1
+                rm -f tailscale_1.62.1_arm64.tgz
+            fi
+            mkdir -p ~/.tailscale_state
+            if ! pgrep -f tailscaled > /dev/null 2>&1; then
+                cd ~/tailscale
+                nohup ./tailscaled --tun=userspace-networking --socks5-server=localhost:1055 \
+                    --statedir=$HOME/.tailscale_state > ~/tailscale/tailscaled.log 2>&1 &
+                sleep 2
+            fi
+            """
+        )
+        # Check auth state
+        _, stdout, _, _ = self.ssh_command(
+            "~/tailscale/tailscale --socket ~/tailscale/tailscaled.sock status >/dev/null 2>&1 && echo ok"
+        )
+        authenticated = "ok" in stdout.read().decode()
+
+        if not authenticated:
+            if not self.tailscale_authkey:
+                raise DeviceInstallationError(
+                    "Tailscale is not authenticated and no tailscale_authkey provided. "
+                    "Generate one at https://login.tailscale.com/admin/settings/keys"
+                )
+            self.logger.info("Authenticating Tailscale with auth key...")
+            self.ssh_command(
+                "~/tailscale/tailscale --socket ~/tailscale/tailscaled.sock up --authkey {key}".format(
+                    key=self.tailscale_authkey
+                )
+            )
+            # Verify auth succeeded
+            _, stdout, _, _ = self.ssh_command(
+                "~/tailscale/tailscale --socket ~/tailscale/tailscaled.sock status >/dev/null 2>&1 && echo ok"
+            )
+            if "ok" not in stdout.read().decode():
+                raise DeviceInstallationError(
+                    "Tailscale authentication failed. The auth key may be invalid, "
+                    "expired, or already consumed. Generate a new one at "
+                    "https://login.tailscale.com/admin/settings/keys"
+                )
+            self.logger.info("Tailscale authenticated successfully")
+        else:
+            self.logger.info("Tailscale already authenticated")
+
+        # Ensure auto-start on future boots
+        self.ssh_command(
+            """
+            grep -q 'tailscaled' ~/.bashrc || cat >> ~/.bashrc << 'EOF'
+if ! pgrep -f tailscaled > /dev/null 2>&1; then
+    cd ~/tailscale && nohup ./tailscaled --tun=userspace-networking \
+        --socks5-server=localhost:1055 --statedir=$HOME/.tailscale_state \
+        > ~/tailscale/tailscaled.log 2>&1 & sleep 1
+fi
+EOF
+            """
+        )
+
+    def _configure_tailscale_env(self, venv_name):
+        """Add Tailscale env vars to a venv's activate script (no-op if venv missing)."""
+        self.ssh_command(
+            """
+            ACT=~/{venv}/bin/activate
+            [ -f "$ACT" ] && ! grep -q 'USE_TAILSCALE' "$ACT" && cat >> "$ACT" << 'EOF'
+export PATH="$HOME/tailscale:$PATH"
+export TS_SOCKET="$HOME/tailscale/tailscaled.sock"
+export USE_TAILSCALE=1
+EOF
+            true
+            """.format(venv=venv_name)
+        )
+
+    def _ensure_socat_bridge(self):
+        """Start a socat bridge so Redis on robot's 127.0.0.1:6379 tunnels to the host's Tailscale IP."""
+        # Get this host's Tailscale IP (the machine running SIC)
+        ts_host_ip = utils.get_ip_adress()
+        if not ts_host_ip.startswith("100."):
+            return  # Not a Tailscale IP, skip
+        self.ssh_command(
+            """
+            if [ -x ~/tailscale/tailscale ] && ! ss -tlnp 2>/dev/null | grep -q ':6379 '; then
+                nohup socat TCP4-LISTEN:6379,bind=127.0.0.1,reuseaddr,fork \
+                    SOCKS5:127.0.0.1:{ts_host_ip}:6379,socksport=1055 > ~/socat_redis.log 2>&1 &
+            fi
+            """.format(ts_host_ip=ts_host_ip)
+        )
+
     def create_test_environment(self):
         """
         Creates a test environment on the Alphamini
@@ -632,9 +743,11 @@ class Alphamini(SICDeviceManager):
 
             self.logger.info("Transferring zip file over to Mini")
 
-            # scp transfer file over
-            with self.SCPClient(self.ssh.get_transport()) as scp:
-                scp.put(zipped_path, "/data/data/com.termux/files/home/sic_in_test/")
+            # Use SFTP instead of SCP to avoid Android FORTIFY umask issue
+            sftp = self.ssh.open_sftp()
+            remote_path = "/data/data/com.termux/files/home/sic_in_test/" + os.path.basename(zipped_path)
+            sftp.put(zipped_path, remote_path)
+            sftp.close()
 
             _, stdout, _, exit_status = self.ssh_command(
                 """
@@ -730,6 +843,9 @@ class Alphamini(SICDeviceManager):
 
     def run_sic(self):
         self.logger.info("Running sic on alphamini...")
+        self._configure_tailscale_env(".venv_sic")
+        self._configure_tailscale_env(".test_venv")
+        self._ensure_socat_bridge()
 
         self.stop_cmd = """
             echo 'Killing all previous robot wrapper processes';

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -657,16 +657,27 @@ EOF
         ts_host_ip = utils.get_ip_adress()
         if not ts_host_ip.startswith("100."):
             return  # Not a Tailscale IP, skip
+
+        # Kill any stale socat first
+        self.ssh_command("pkill -f socat || true")
+        time.sleep(1)
+
+        # Start socat in its own thread (same pattern as tailscaled / SIC)
         self.ssh_command(
-            """
-            if [ -x ~/tailscale/tailscale ]; then
-                pkill -f socat || true
-                sleep 1
-                nohup socat TCP4-LISTEN:6379,bind=127.0.0.1,reuseaddr,fork \
-                    SOCKS5:127.0.0.1:{ts_host_ip}:6379,socksport=1055 > ~/socat_redis.log 2>&1 &
-            fi
-            """.format(ts_host_ip=ts_host_ip)
+            "socat TCP4-LISTEN:6379,bind=127.0.0.1,reuseaddr,fork "
+            "SOCKS5:127.0.0.1:{ts_host_ip}:6379,socksport=1055".format(ts_host_ip=ts_host_ip),
+            create_thread=True, get_pty=False
         )
+
+        # Wait up to 5s for port to be listening
+        for _ in range(5):
+            _, stdout, _, _ = self.ssh_command(
+                "ss -tln | grep -q ':6379 ' && echo ok"
+            )
+            if "ok" in stdout.read().decode():
+                return
+            time.sleep(1)
+        self.logger.warning("socat Redis bridge may not have started")
 
     def create_test_environment(self):
         """


### PR DESCRIPTION
Issue number: resolves #143 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Running applications on the robot remotely across different networks is not supported.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- **First-time setup:** Connect the laptop and robot to the same local network (with internet). Initialize with `USE_TAILSCALE=1`, a Tailscale auth key (reusable or not, generated from [here](https://login.tailscale.com/admin/settings/keys)) within initialisation alpha mini, and redis_ip set to localhost / 127.0.0.1.
- **Verify:** Confirm the robot appears in your Tailscale devices list and is online (as well as your own laptop).
- **After setup:** The host and robot can be on any network, anywhere. Just set USE_TAILSCALE=1 in .env, mini_ip to the robot's Tailscale IP and run the interaction.

See [this comment](https://github.com/Social-AI-VU/social-interaction-cloud/issues/143#issuecomment-4258074203) for example demo code.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
