### PR TITLE
143 bugfix

### DIFF
--- a/sic_framework/core/utils.py
+++ b/sic_framework/core/utils.py
@@ -33,29 +33,26 @@ def get_ip_adress():
         import subprocess
 
         ts_socket = os.environ.get("TS_SOCKET")
+        cmd = ["tailscale"]
+        if ts_socket:
+            cmd += ["--socket", ts_socket]
+        cmd += ["status", "--json"]
 
-        for ts_cmd in ("tailscale", "./tailscale"):
-            try:
-                cmd = [ts_cmd]
-                if ts_socket:
-                    cmd += ["--socket", ts_socket]
-                cmd += ["status", "--json"]
-
-                result = subprocess.run(
-                    cmd, capture_output=True, text=True, timeout=5
-                )
-                if result.returncode == 0:
-                    data = json.loads(result.stdout)
-                    ips = data.get("Self", {}).get("TailscaleIPs", [])
-                    if ips:
-                        return ips[0]
-            except (FileNotFoundError, ValueError, KeyError, subprocess.TimeoutExpired):
-                continue
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0:
+                data = json.loads(result.stdout)
+                ips = data.get("Self", {}).get("TailscaleIPs", [])
+                if ips:
+                    return ips[0]
+        except (FileNotFoundError, ValueError, KeyError, subprocess.TimeoutExpired):
+            pass
 
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(0)
     try:
-        # doesn't even have to be reachable
         s.connect(("10.254.254.254", 1))
         IP = s.getsockname()[0]
     except Exception:

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -642,10 +642,9 @@ class Alphamini(SICDeviceManager):
         self.ssh_command(
             """
             ACT=~/{venv}/bin/activate
-            [ -f "$ACT" ] && ! grep -q 'USE_TAILSCALE' "$ACT" && cat >> "$ACT" << 'EOF'
+            [ -f "$ACT" ] && ! grep -q 'TS_SOCKET' "$ACT" && cat >> "$ACT" << 'EOF'
 export PATH="$HOME/tailscale:$PATH"
 export TS_SOCKET="$HOME/tailscale/tailscaled.sock"
-export USE_TAILSCALE=1
 EOF
             true
             """.format(venv=venv_name)
@@ -915,6 +914,10 @@ EOF
             """
                 + self.start_cmd
             )
+
+        # Inject USE_TAILSCALE for this session only (non-persistent)
+        if use_tailscale:
+            self.start_cmd = "export USE_TAILSCALE=1; " + self.start_cmd
 
         self.logger.info("starting SIC on alphamini")
 

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -673,15 +673,19 @@ EOF
             create_thread=True, get_pty=False
         )
 
-        # Wait up to 5s for port to be listening
-        for _ in range(5):
+        # Verify bridge works end-to-end with a Redis ping
+        for i in range(5):
             _, stdout, _, _ = self.ssh_command(
-                "ss -tln | grep -q ':6379 ' && echo ok"
+                "(printf 'AUTH changemeplease\\r\\nPING\\r\\n'; sleep 1) | nc 127.0.0.1 6379"
             )
-            if "ok" in stdout.read().decode():
+            if "PONG" in stdout.read().decode():
+                self.logger.info("Socat Redis bridge verified")
                 return
-            time.sleep(1)
-        self.logger.warning("socat Redis bridge may not have started")
+            time.sleep(2)
+        raise DeviceExecutionError(
+            "Socat Redis bridge failed to connect to host Redis. "
+            "Check that Redis is running on the host and accessible via Tailscale."
+        )
 
     def create_test_environment(self):
         """

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -871,9 +871,11 @@ EOF
 
     def run_sic(self):
         self.logger.info("Running sic on alphamini...")
-        self._configure_tailscale_env(".venv_sic")
-        self._configure_tailscale_env(".test_venv")
-        self._ensure_socat_bridge()
+        use_tailscale = os.environ.get("USE_TAILSCALE", "").lower() in ("1", "true", "yes")
+        if use_tailscale:
+            self._configure_tailscale_env(".venv_sic")
+            self._configure_tailscale_env(".test_venv")
+            self._ensure_socat_bridge()
 
         self.stop_cmd = """
             echo 'Killing all previous robot wrapper processes';

--- a/sic_framework/devices/alphamini.py
+++ b/sic_framework/devices/alphamini.py
@@ -148,6 +148,11 @@ class Alphamini(SICDeviceManager):
             ts_ip = stdout.read().decode().strip()
             if ts_ip:
                 self.device_ip = ts_ip
+            else:
+                raise DeviceInstallationError(
+                    "Tailscale is authenticated but could not retrieve its IP address. "
+                    "Check that the daemon is running and connected."
+                )
 
         if self.dev_test:
             self.create_test_environment()


### PR DESCRIPTION
Issue number: resolves #145 

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The robot's get_ip_adress() tried ./tailscale as a fallback command. This resolved to the current working directory, not ~/tailscale/, causing a PermissionError. It was triggered because USE_TAILSCALE=1 was persisted in the venv activate script.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed the ./tailscale fallback from get_ip_adress(). The binary is now found only via PATH, which is set by _configure_tailscale_env. 
- Made USE_TAILSCALE=1 non-persistent by removing it from the venv activate script. It is now injected inline per-session in run_sic() via export USE_TAILSCALE=1; prepended to the start command. Only PATH and TS_SOCKET persist in the activate script. These are harmless without USE_TAILSCALE being set. 
- Added a DeviceInstallationError if Tailscale authenticates but the IP query fails, to catch unexpected daemon issues early. 
- Replaced the socat port-open check with an end-to-end Redis ping through the full tunnel. This catches SOCKS5 errors early and raises a DeviceExecutionError if the bridge cannot be verified after 5 retries.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
