### PR TITLE
Honor pages root template in webserver default route

### DIFF
--- a/sic_framework/services/webserver/webserver_service.py
+++ b/sic_framework/services/webserver/webserver_service.py
@@ -495,11 +495,22 @@ class WebserverComponent(SICService):
 
     def register_routes(self):
         """Register Flask routes."""
+        pages = getattr(self.params, "pages", None) or {}
+        root_template = None
+        if isinstance(pages, dict):
+            root_template = pages.get("/") or pages.get("")
+
         @self.app.route("/")
         def index():
+            template_name = root_template or "index.html"
             try:
-                return render_template("index.html")
+                return render_template(template_name)
             except Exception:
+                if root_template:
+                    return (
+                        f"<h1>SIC Webserver Running</h1>"
+                        f"<p>Template {root_template!r} not found.</p>"
+                    )
                 return "<h1>SIC Webserver Running</h1><p>No index.html found.</p>"
 
         @self.app.route("/healthz", methods=["GET"])
@@ -538,14 +549,15 @@ class WebserverComponent(SICService):
             self.output_message(ButtonClicked(button=data))
             return ("", 204)
 
-        # Configurable page registry (safe allowlist).
-        pages = getattr(self.params, "pages", None) or {}
+        # Configurable page registry (safe allowlist). Skip "/" — handled above.
         for route, template_name in pages.items():
             try:
                 if not isinstance(route, str) or not route:
                     continue
                 if not route.startswith("/"):
                     route = "/" + route
+                if route in ("/", ""):
+                    continue
                 if not isinstance(template_name, str) or not template_name:
                     continue
 


### PR DESCRIPTION
## Summary

- The SIC webserver `/` route now renders `pages["/"]` when configured, instead of always requiring `index.html`.
- Avoids duplicate template files and fixes apps that map `/` to a custom template (e.g. `transcript.html`).

## Related work

Used by RobotDetective `landon_experiment` live transcript UI (PRs on `landon` / `landon-thesis`).

## Test plan

- [ ] `WebserverConf(pages={"/": "transcript.html"})` serves that page at `/`.
- [ ] Apps with only `index.html` still work when `pages` is unset.