### PR TITLE
Service containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+**/__pycache__
+**/*.py[cod]
+.pytest_cache
+.mypy_cache
+.ruff_cache
+*.egg-info
+dist
+build
+.coverage
+htmlcov
+docs/_build

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -34,6 +34,13 @@ Redis registries (multi-user)
 
    architecture/redis_registries
 
+Docker
+------
+
+.. toctree::
+
+   architecture/docker
+
 Model Context Protocol (MCP)
 ----------------------------
 

--- a/docs/source/architecture/docker.rst
+++ b/docs/source/architecture/docker.rst
@@ -92,13 +92,19 @@ SIC builds missing images automatically on first startup. Rebuild when:
 - You changed local SIC framework code and need the container to include it.
 - A container is still running an older image than expected.
 
-To force SIC to rebuild before starting:
+**Docker Desktop (recommended):** Open **Containers**, find the compose project
+(matching the top-level ``name:`` field, for example ``sic-my-demo``). Stop the
+stack, then delete the project or its containers so the next demo run builds and
+starts fresh images. You can also rebuild from the **Images** or **Builds** view
+if you use Docker Desktop's image build UI.
+
+**From your demo script:** force a rebuild on the next startup:
 
 .. code-block:: bash
 
    SIC_COMPOSE_REBUILD=1 python demo_RAG_chat.py
 
-You can also rebuild manually from the demo directory:
+**Command line (advanced):** from the demo directory:
 
 .. code-block:: bash
 
@@ -109,15 +115,19 @@ Then start the demo normally.
 Looking at container logs
 -------------------------
 
-Use the compose project name from the top-level ``name:`` field:
+**Docker Desktop (recommended):** Open **Containers** and select the compose
+project (same name as the top-level ``name:`` field, for example
+``sic-my-demo``). Click a service to stream its logs, or open the project view
+to see all services in the stack together.
+
+**Command line (advanced):** use the compose project name from that ``name:``
+field:
 
 .. code-block:: bash
 
    docker compose -f docker-compose.yml -p sic-my-demo logs
    docker compose -f docker-compose.yml -p sic-my-demo logs -f
    docker compose -f docker-compose.yml -p sic-my-demo logs -f gpt
-
-Docker Desktop shows the same containers grouped under the compose project name.
 
 How containers know the SIC version
 -----------------------------------
@@ -173,43 +183,40 @@ Use manual mode when:
 Troubleshooting
 ---------------
 
+Most issues are easiest to fix in **Docker Desktop** before using the command
+line. Open **Containers**, find the compose project (its name matches the
+top-level ``name:`` in your ``docker-compose.yml``), then inspect logs, stop
+individual services, or delete the whole stack.
+
 ``SIC_HOST_IP`` is missing
-   You are probably running ``docker compose`` manually. Set it before the
-   command:
+   Prefer starting the stack by running the demo (``SICApplication`` sets
+   ``SIC_HOST_IP`` for you). If you start compose yourself, set the variable
+   before ``docker compose up``:
 
    .. code-block:: bash
 
       SIC_HOST_IP=<your-host-ip> docker compose -f docker-compose.yml -p sic-my-demo up
 
 Port ``6379`` is already allocated
-   Another Redis container or local Redis process is running. Check:
+   Another Redis container or a local Redis process is using the port.
+
+   **Docker Desktop:** In **Containers**, look for anything publishing port
+   ``6379`` (often an old demo stack). Stop or delete those containers. To remove
+   an entire old compose project, select it and choose **Delete** (or stop all
+   services in that project).
+
+   **Command line (advanced):**
 
    .. code-block:: bash
 
       docker ps --filter publish=6379
-
-   Stop the old compose project:
-
-   .. code-block:: bash
-
       docker compose -f docker-compose.yml -p sic-my-demo down --remove-orphans
 
-Containers remain after Ctrl+C
-   Make sure the demo is using the SIC checkout you edited. Prefer running with
-   the project virtual environment rather than a system Python:
-
-   .. code-block:: bash
-
-      /path/to/.venv/bin/python demo_RAG_chat.py
-
-   If you use ``sudo``, preserve the environment and explicit Python path:
-
-   .. code-block:: bash
-
-      sudo -E /path/to/.venv/bin/python demo_RAG_chat.py
-
 Image changes are not picked up
-   Rebuild with ``SIC_COMPOSE_REBUILD=1`` or run ``docker compose build``.
+   **Docker Desktop:** Rebuild or remove the affected service containers (see
+   `Rebuilding containers`_). **From the demo:**
+   ``SIC_COMPOSE_REBUILD=1 python <your_demo>.py``. **Command line:**
+   ``docker compose build``.
 
 Service cannot connect to Redis
    Inside Docker, services should use ``DB_IP: redis``. Host-side SIC code should

--- a/docs/source/architecture/docker.rst
+++ b/docs/source/architecture/docker.rst
@@ -1,0 +1,216 @@
+Docker in SIC
+=============
+
+SIC can run services in Docker containers so demos do not require you to start
+Redis and every component service manually. This is optional: if an application
+does not pass a compose file to ``SICApplication``, SIC assumes the required
+services are already running.
+
+How compose files work
+----------------------
+
+A demo can ask SIC to start a Docker Compose stack by passing a compose file:
+
+.. code-block:: python
+
+   app = SICApplication(services_compose="docker-compose.yml")
+
+For class-based demos:
+
+.. code-block:: python
+
+   super(MyDemo, self).__init__(services_compose="docker-compose.yml")
+
+The path is resolved relative to the demo file that creates the
+``SICApplication``. During startup, SIC:
+
+1. Resolves the compose file path.
+2. Determines the compose project name from the top-level ``name:`` field.
+3. Sets SIC-specific compose environment variables.
+4. Builds missing service images when needed.
+5. Runs ``docker compose up -d --wait``.
+6. Waits until Redis is reachable on the host.
+
+On shutdown, SIC runs ``docker compose down --remove-orphans`` for the same
+compose project.
+
+Creating a compose file
+-----------------------
+
+Start with a top-level ``name:`` so Docker Desktop and CLI commands show a stable
+project name:
+
+.. code-block:: yaml
+
+   name: sic-my-demo
+
+   services:
+     redis:
+       image: redis/redis-stack:latest
+       ports:
+         - "6379:6379"
+       environment:
+         REDIS_ARGS: "--requirepass changemeplease --appendonly yes"
+       healthcheck:
+         test: ["CMD", "redis-cli", "-a", "changemeplease", "ping"]
+         interval: 2s
+         timeout: 3s
+         retries: 15
+
+     gpt:
+       build:
+         context: ${SIC_BUILD_CONTEXT}
+         dockerfile: ${SIC_DOCKER_ROOT}/docker/services/gpt/Dockerfile
+         target: ${SIC_BUILD_TARGET}
+         args:
+           SIC_VERSION: ${SIC_VERSION}
+       environment:
+         SIC_IP: ${SIC_HOST_IP}
+         DB_IP: redis
+         DB_PORT: "6379"
+         DB_PASS: changemeplease
+       depends_on:
+         redis:
+           condition: service_healthy
+
+Use ``DB_IP: redis`` inside containers because Redis is another compose service.
+Use ``SIC_IP: ${SIC_HOST_IP}`` so services know how to identify the client host
+running the SIC application.
+
+The ``build.dockerfile`` entry is optional. If you provide it, Compose builds the
+service image from SIC's Dockerfiles. If you use an ``image:`` instead, Compose
+pulls or reuses that image. If neither a compose service nor a Dockerfile/image
+is provided, then that SIC service must already be running manually.
+
+Rebuilding containers
+---------------------
+
+SIC builds missing images automatically on first startup. Rebuild when:
+
+- You changed a SIC Dockerfile.
+- You changed service dependencies or package extras.
+- You changed local SIC framework code and need the container to include it.
+- A container is still running an older image than expected.
+
+To force SIC to rebuild before starting:
+
+.. code-block:: bash
+
+   SIC_COMPOSE_REBUILD=1 python demo_RAG_chat.py
+
+You can also rebuild manually from the demo directory:
+
+.. code-block:: bash
+
+   SIC_HOST_IP=<your-host-ip> docker compose -f docker-compose.yml -p sic-my-demo build
+
+Then start the demo normally.
+
+Looking at container logs
+-------------------------
+
+Use the compose project name from the top-level ``name:`` field:
+
+.. code-block:: bash
+
+   docker compose -f docker-compose.yml -p sic-my-demo logs
+   docker compose -f docker-compose.yml -p sic-my-demo logs -f
+   docker compose -f docker-compose.yml -p sic-my-demo logs -f gpt
+
+Docker Desktop shows the same containers grouped under the compose project name.
+
+How containers know the SIC version
+-----------------------------------
+
+When SIC starts a compose stack, it sets these environment variables for Compose:
+
+``SIC_DOCKER_ROOT``
+   Location of SIC's packaged Dockerfiles.
+
+``SIC_BUILD_CONTEXT``
+   The Docker build context. In a source checkout this is the repository root;
+   in an installed package it is the package directory.
+
+``SIC_BUILD_TARGET``
+   ``local`` for source checkouts, ``pypi`` for installed packages.
+
+``SIC_VERSION``
+   The ``social-interaction-cloud`` package version. You can override it by
+   setting ``SIC_VERSION`` yourself.
+
+``SIC_HOST_IP``
+   The host IP of the running SIC application. Services use this as ``SIC_IP``.
+
+The service Dockerfiles use ``SIC_VERSION`` as a build argument. This lets
+containers install the same released SIC package version as the host, unless you
+are running from a local source checkout with the ``local`` build target.
+
+Manual runs without compose
+---------------------------
+
+Compose is only a convenience. If you omit ``services_compose``:
+
+.. code-block:: python
+
+   app = SICApplication()
+
+SIC does not start or stop any containers. In that mode, you must start Redis
+and the service processes yourself, for example:
+
+.. code-block:: bash
+
+   run-redis
+   run-gpt
+   run-elevenlabs-tts
+
+Use manual mode when:
+
+- You are debugging a service directly in Python.
+- A service runs on another machine.
+- You already have Redis or a component manager running.
+- You do not want Docker Desktop involved in the lifecycle.
+
+Troubleshooting
+---------------
+
+``SIC_HOST_IP`` is missing
+   You are probably running ``docker compose`` manually. Set it before the
+   command:
+
+   .. code-block:: bash
+
+      SIC_HOST_IP=<your-host-ip> docker compose -f docker-compose.yml -p sic-my-demo up
+
+Port ``6379`` is already allocated
+   Another Redis container or local Redis process is running. Check:
+
+   .. code-block:: bash
+
+      docker ps --filter publish=6379
+
+   Stop the old compose project:
+
+   .. code-block:: bash
+
+      docker compose -f docker-compose.yml -p sic-my-demo down --remove-orphans
+
+Containers remain after Ctrl+C
+   Make sure the demo is using the SIC checkout you edited. Prefer running with
+   the project virtual environment rather than a system Python:
+
+   .. code-block:: bash
+
+      /path/to/.venv/bin/python demo_RAG_chat.py
+
+   If you use ``sudo``, preserve the environment and explicit Python path:
+
+   .. code-block:: bash
+
+      sudo -E /path/to/.venv/bin/python demo_RAG_chat.py
+
+Image changes are not picked up
+   Rebuild with ``SIC_COMPOSE_REBUILD=1`` or run ``docker compose build``.
+
+Service cannot connect to Redis
+   Inside Docker, services should use ``DB_IP: redis``. Host-side SIC code should
+   use ``127.0.0.1`` with the published port.

--- a/setup.py
+++ b/setup.py
@@ -134,6 +134,9 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(),
     package_data={
+        "sic_framework": [
+            "docker/**",
+        ],
         "sic_framework.services.face_detection": [
             "haarcascade_frontalface_default.xml",
         ],

--- a/sic_framework/core/sic_application.py
+++ b/sic_framework/core/sic_application.py
@@ -58,8 +58,8 @@ class SICApplication(object):
         :param services_compose: Optional path to a docker-compose.yml (relative to the
             caller's source file). When set, the stack is started before Redis connects
             and stopped during cleanup.
-        :param services_compose_project: Optional docker compose project name. Defaults
-            to a name derived from the compose file's directory.
+        :param services_compose_project: Optional override for the Docker Compose
+            project name. By default the ``name:`` field in the compose file is used.
         """
         # Only initialize once (singleton pattern)
         if getattr(self, "_initialized", False):
@@ -73,6 +73,7 @@ class SICApplication(object):
         self._shutdown_handler_registered = False
         self._services_compose_path = None
         self._services_compose_project = None
+        self._services_compose_project_override = None
         self._services_compose_started = False
 
         if services_compose:
@@ -86,12 +87,16 @@ class SICApplication(object):
                 services_compose, caller_file=caller_file
             )
             self.client_ip = utils.get_ip_adress()
-            project_name = services_compose_project or sic_compose.default_project_name(
-                compose_path
+            sic_compose.start(
+                compose_path,
+                self.client_ip,
+                project_name=services_compose_project,
             )
-            sic_compose.start(compose_path, project_name, self.client_ip)
             self._services_compose_path = compose_path
-            self._services_compose_project = project_name
+            self._services_compose_project = sic_compose.compose_project_name(
+                compose_path, services_compose_project
+            )
+            self._services_compose_project_override = services_compose_project
             self._services_compose_started = True
         else:
             self.client_ip = utils.get_ip_adress()
@@ -324,7 +329,8 @@ class SICApplication(object):
                     )
                 )
             sic_compose.stop(
-                self._services_compose_path, self._services_compose_project
+                self._services_compose_path,
+                project_name=self._services_compose_project_override,
             )
             self._services_compose_started = False
 

--- a/sic_framework/core/sic_application.py
+++ b/sic_framework/core/sic_application.py
@@ -22,6 +22,7 @@ try:
 except ImportError:  # pragma: no cover
     import Queue as queue  # Python 2
 from sic_framework.core.sic_redis import SICRedisConnection
+from sic_framework.core import sic_compose
 
 class SICApplication(object):
     """
@@ -46,9 +47,19 @@ class SICApplication(object):
                 cls._instance = super(SICApplication, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self):
+    def __init__(
+        self,
+        services_compose=None,
+        services_compose_project=None,
+    ):
         """
         Initialize runtime state and register exit handler once.
+
+        :param services_compose: Optional path to a docker-compose.yml (relative to the
+            caller's source file). When set, the stack is started before Redis connects
+            and stopped during cleanup.
+        :param services_compose_project: Optional docker compose project name. Defaults
+            to a name derived from the compose file's directory.
         """
         # Only initialize once (singleton pattern)
         if getattr(self, "_initialized", False):
@@ -60,9 +71,32 @@ class SICApplication(object):
         self._active_connectors = weakref.WeakSet()
         self._active_devices = weakref.WeakSet()
         self._shutdown_handler_registered = False
-        
+        self._services_compose_path = None
+        self._services_compose_project = None
+        self._services_compose_started = False
+
+        if services_compose:
+            frame = inspect.currentframe()
+            try:
+                caller = frame.f_back
+                caller_file = caller.f_globals.get("__file__") if caller else None
+            finally:
+                del frame
+            compose_path = sic_compose.resolve_compose_path(
+                services_compose, caller_file=caller_file
+            )
+            self.client_ip = utils.get_ip_adress()
+            project_name = services_compose_project or sic_compose.default_project_name(
+                compose_path
+            )
+            sic_compose.start(compose_path, project_name, self.client_ip)
+            self._services_compose_path = compose_path
+            self._services_compose_project = project_name
+            self._services_compose_started = True
+        else:
+            self.client_ip = utils.get_ip_adress()
+
         self.shutdown_event = threading.Event()
-        self.client_ip = utils.get_ip_adress()
 
         # Background exception handling
         self._background_exception_queue = queue.Queue()
@@ -281,6 +315,18 @@ class SICApplication(object):
         if self._redis is not None:
             self._redis.close()
             self._redis = None
+
+        if self._services_compose_started:
+            if log_shutdown:
+                self.logger.info(
+                    "Stopping docker compose stack {}".format(
+                        self._services_compose_project
+                    )
+                )
+            sic_compose.stop(
+                self._services_compose_path, self._services_compose_project
+            )
+            self._services_compose_started = False
 
     def exit_handler(self, signum=None, frame=None):
         """Gracefully stop connectors and close Redis, then exit main thread.

--- a/sic_framework/core/sic_application.py
+++ b/sic_framework/core/sic_application.py
@@ -75,6 +75,7 @@ class SICApplication(object):
         self._services_compose_project = None
         self._services_compose_project_override = None
         self._services_compose_started = False
+        self._services_compose_monitor = None
 
         if services_compose:
             frame = inspect.currentframe()
@@ -98,6 +99,12 @@ class SICApplication(object):
             )
             self._services_compose_project_override = services_compose_project
             self._services_compose_started = True
+            self._services_compose_monitor = sic_compose.start_service_monitor(
+                compose_path,
+                services_compose_project,
+                self.client_ip,
+                self.report_background_exception,
+            )
         else:
             self.client_ip = utils.get_ip_adress()
 
@@ -322,6 +329,9 @@ class SICApplication(object):
             self._redis = None
 
         if self._services_compose_started:
+            if self._services_compose_monitor is not None:
+                self._services_compose_monitor.stop()
+                self._services_compose_monitor = None
             if log_shutdown:
                 self.logger.info(
                     "Stopping docker compose stack {}".format(

--- a/sic_framework/core/sic_application.py
+++ b/sic_framework/core/sic_application.py
@@ -47,19 +47,13 @@ class SICApplication(object):
                 cls._instance = super(SICApplication, cls).__new__(cls)
         return cls._instance
 
-    def __init__(
-        self,
-        services_compose=None,
-        services_compose_project=None,
-    ):
+    def __init__(self, services_compose=None):
         """
         Initialize runtime state and register exit handler once.
 
         :param services_compose: Optional path to a docker-compose.yml (relative to the
             caller's source file). When set, the stack is started before Redis connects
             and stopped during cleanup.
-        :param services_compose_project: Optional override for the Docker Compose
-            project name. By default the ``name:`` field in the compose file is used.
         """
         # Only initialize once (singleton pattern)
         if getattr(self, "_initialized", False):
@@ -73,9 +67,10 @@ class SICApplication(object):
         self._shutdown_handler_registered = False
         self._services_compose_path = None
         self._services_compose_project = None
-        self._services_compose_project_override = None
         self._services_compose_started = False
         self._services_compose_monitor = None
+
+        self.client_ip = utils.get_ip_adress()
 
         if services_compose:
             frame = inspect.currentframe()
@@ -84,29 +79,7 @@ class SICApplication(object):
                 caller_file = caller.f_globals.get("__file__") if caller else None
             finally:
                 del frame
-            compose_path = sic_compose.resolve_compose_path(
-                services_compose, caller_file=caller_file
-            )
-            self.client_ip = utils.get_ip_adress()
-            sic_compose.start(
-                compose_path,
-                self.client_ip,
-                project_name=services_compose_project,
-            )
-            self._services_compose_path = compose_path
-            self._services_compose_project = sic_compose.compose_project_name(
-                compose_path, services_compose_project
-            )
-            self._services_compose_project_override = services_compose_project
-            self._services_compose_started = True
-            self._services_compose_monitor = sic_compose.start_service_monitor(
-                compose_path,
-                services_compose_project,
-                self.client_ip,
-                self.report_background_exception,
-            )
-        else:
-            self.client_ip = utils.get_ip_adress()
+            self._start_services_compose(services_compose, caller_file)
 
         self.shutdown_event = threading.Event()
 
@@ -126,6 +99,39 @@ class SICApplication(object):
         self.register_exit_handler()
 
         self._initialized = True
+
+    def _start_services_compose(self, services_compose, caller_file):
+        """Resolve, start, and monitor the demo docker-compose stack."""
+        compose_path = sic_compose.resolve_compose_path(
+            services_compose, caller_file=caller_file
+        )
+        sic_compose.start(compose_path, self.client_ip)
+        self._services_compose_path = compose_path
+        self._services_compose_project = sic_compose.compose_project_name(compose_path)
+        self._services_compose_started = True
+        self._services_compose_monitor = sic_compose.start_service_monitor(
+            compose_path,
+            None,
+            self.client_ip,
+            self.report_background_exception,
+        )
+
+    def _stop_services_compose(self, log_shutdown=True):
+        """Stop the compose monitor and tear down containers."""
+        if not self._services_compose_started:
+            return
+
+        if self._services_compose_monitor is not None:
+            self._services_compose_monitor.stop()
+            self._services_compose_monitor = None
+        if log_shutdown:
+            self.logger.info(
+                "Stopping docker compose stack {}".format(
+                    self._services_compose_project
+                )
+            )
+        sic_compose.stop(self._services_compose_path)
+        self._services_compose_started = False
 
     # ------------ Public API (instance methods) ------------
     def register_connector(self, connector):
@@ -328,21 +334,7 @@ class SICApplication(object):
             self._redis.close()
             self._redis = None
 
-        if self._services_compose_started:
-            if self._services_compose_monitor is not None:
-                self._services_compose_monitor.stop()
-                self._services_compose_monitor = None
-            if log_shutdown:
-                self.logger.info(
-                    "Stopping docker compose stack {}".format(
-                        self._services_compose_project
-                    )
-                )
-            sic_compose.stop(
-                self._services_compose_path,
-                project_name=self._services_compose_project_override,
-            )
-            self._services_compose_started = False
+        self._stop_services_compose(log_shutdown=log_shutdown)
 
     def exit_handler(self, signum=None, frame=None):
         """Gracefully stop connectors and close Redis, then exit main thread.

--- a/sic_framework/core/sic_application.py
+++ b/sic_framework/core/sic_application.py
@@ -57,6 +57,14 @@ class SICApplication(object):
         """
         # Only initialize once (singleton pattern)
         if getattr(self, "_initialized", False):
+            if services_compose and not self._services_compose_path:
+                frame = inspect.currentframe()
+                try:
+                    caller = frame.f_back
+                    caller_file = caller.f_globals.get("__file__") if caller else None
+                finally:
+                    del frame
+                self._start_services_compose(services_compose, caller_file)
             return
 
         # Runtime state
@@ -105,32 +113,23 @@ class SICApplication(object):
         compose_path = sic_compose.resolve_compose_path(
             services_compose, caller_file=caller_file
         )
-        sic_compose.start(compose_path, self.client_ip)
         self._services_compose_path = compose_path
         self._services_compose_project = sic_compose.compose_project_name(compose_path)
+        sic_compose.start(
+            compose_path, self.client_ip, project_name=self._services_compose_project
+        )
         self._services_compose_started = True
         self._services_compose_monitor = sic_compose.start_service_monitor(
             compose_path,
-            None,
+            self._services_compose_project,
             self.client_ip,
             self.report_background_exception,
         )
 
     def _stop_services_compose(self, log_shutdown=True):
-        """Stop the compose monitor and tear down containers."""
-        if not self._services_compose_started:
-            return
-
-        if self._services_compose_monitor is not None:
-            self._services_compose_monitor.stop()
-            self._services_compose_monitor = None
-        if log_shutdown:
-            self.logger.info(
-                "Stopping docker compose stack {}".format(
-                    self._services_compose_project
-                )
-            )
-        sic_compose.stop(self._services_compose_path)
+        """Tear down the docker-compose stack (after connectors and Redis are closed)."""
+        sic_compose.stop_running()
+        self._services_compose_path = None
         self._services_compose_started = False
 
     # ------------ Public API (instance methods) ------------
@@ -252,89 +251,96 @@ class SICApplication(object):
 
         self._cleanup_in_progress = True
 
-        if log_shutdown:
-            self.logger.info("signal interrupt received, exiting...")
+        if self._services_compose_monitor is not None:
+            self._services_compose_monitor.stop()
+            self._services_compose_monitor = None
 
-        if self.shutdown_event is not None:
+        try:
             if log_shutdown:
-                self.logger.info("Setting shutdown event")
-            self.shutdown_event.set()
+                self.logger.info("signal interrupt received, exiting...")
 
-        devices_to_stop = list(self._active_devices)
-        if log_shutdown:
-            self.logger.info("Stopping devices")
-        for device in devices_to_stop:
-            try:
+            if self.shutdown_event is not None:
                 if log_shutdown:
-                    self.logger.info("Stopping device {}".format(device.name))
-                for connector in device.connectors.values():
-                    connector_name = getattr(connector, "component_endpoint", "unknown")
-                    if log_shutdown:
-                        self.logger.info(
-                            "Stopping component {} from device {}".format(
-                                connector_name, device.name
-                            )
-                        )
-                    connector.stop_component()
-                device.stop_device()
-            except Exception as e:
-                self.logger.error("Error stopping device {}: {}".format(device.name, e))
+                    self.logger.info("Setting shutdown event")
+                self.shutdown_event.set()
 
-        connectors_to_stop = [
-            c for c in self._active_connectors if not getattr(c, "_stopped", False)
-        ]
-        if log_shutdown:
-            self.logger.info(
-                "Stopping remaining non-device components (found {count})".format(
-                    count=len(connectors_to_stop)
-                )
-            )
-        for i, connector in enumerate(connectors_to_stop):
-            connector_name = getattr(connector, "component_endpoint", "unknown")
+            devices_to_stop = list(self._active_devices)
+            if log_shutdown:
+                self.logger.info("Stopping devices")
+            for device in devices_to_stop:
+                try:
+                    if log_shutdown:
+                        self.logger.info("Stopping device {}".format(device.name))
+                    for connector in device.connectors.values():
+                        connector_name = getattr(
+                            connector, "component_endpoint", "unknown"
+                        )
+                        if log_shutdown:
+                            self.logger.info(
+                                "Stopping component {} from device {}".format(
+                                    connector_name, device.name
+                                )
+                            )
+                        connector.stop_component()
+                    device.stop_device()
+                except Exception as e:
+                    self.logger.error(
+                        "Error stopping device {}: {}".format(device.name, e)
+                    )
+
+            connectors_to_stop = [
+                c
+                for c in self._active_connectors
+                if not getattr(c, "_stopped", False)
+            ]
             if log_shutdown:
                 self.logger.info(
-                    "Stopping component {i}/{total}: {name}".format(
-                        i=i + 1, total=len(connectors_to_stop), name=connector_name
+                    "Stopping remaining non-device components (found {count})".format(
+                        count=len(connectors_to_stop)
                     )
                 )
-            try:
-                connector.stop_component()
-            except Exception as e:
-                self.logger.warning(
-                    "Warning: Error stopping component {name}: {e}".format(
-                        name=connector_name, e=e
+            for i, connector in enumerate(connectors_to_stop):
+                connector_name = getattr(connector, "component_endpoint", "unknown")
+                if log_shutdown:
+                    self.logger.info(
+                        "Stopping component {i}/{total}: {name}".format(
+                            i=i + 1, total=len(connectors_to_stop), name=connector_name
+                        )
                     )
-                )
-
-        # Best-effort cleanup in case any reservations/data streams survived
-        # component/device shutdown (e.g. abrupt exits or partial failures).
-        if self._redis is not None:
-            try:
-                self.logger.info(
-                    "Removing lingering reservations/data streams for client {}".format(
-                        self.client_ip
+                try:
+                    connector.stop_component()
+                except Exception as e:
+                    self.logger.warning(
+                        "Warning: Error stopping component {name}: {e}".format(
+                            name=connector_name, e=e
+                        )
                     )
-                )
-                self._redis.remove_client(self.client_ip)
-            except Exception as e:
-                self.logger.warning(
-                    "Warning: Could not fully cleanup client reservation state: {}".format(
-                        e
+
+            if self._redis is not None:
+                try:
+                    self.logger.info(
+                        "Removing lingering reservations/data streams for client {}".format(
+                            self.client_ip
+                        )
                     )
-                )
+                    self._redis.remove_client(self.client_ip)
+                except Exception as e:
+                    self.logger.warning(
+                        "Warning: Could not fully cleanup client reservation state: {}".format(
+                            e
+                        )
+                    )
 
-        self.logger.info("All components stopped, stopping logging thread")
-        
-        # Stop the SICClientLog thread before closing Redis
-        sic_logging.SIC_CLIENT_LOG.stop()
+            self.logger.info("All components stopped, stopping logging thread")
+            sic_logging.SIC_CLIENT_LOG.stop()
 
-        if log_shutdown:
-            self.logger.info("Shutting down Redis connection")
-        if self._redis is not None:
-            self._redis.close()
-            self._redis = None
-
-        self._stop_services_compose(log_shutdown=log_shutdown)
+            if log_shutdown:
+                self.logger.info("Shutting down Redis connection")
+            if self._redis is not None:
+                self._redis.close()
+                self._redis = None
+        finally:
+            self._stop_services_compose(log_shutdown=log_shutdown)
 
     def exit_handler(self, signum=None, frame=None):
         """Gracefully stop connectors and close Redis, then exit main thread.

--- a/sic_framework/core/sic_application.py
+++ b/sic_framework/core/sic_application.py
@@ -22,7 +22,37 @@ try:
 except ImportError:  # pragma: no cover
     import Queue as queue  # Python 2
 from sic_framework.core.sic_redis import SICRedisConnection
-from sic_framework.core import sic_compose
+
+if sys.version_info[0] >= 3:
+    from sic_framework.core import sic_compose
+else:
+
+    class _ComposeStub(object):
+        """Docker compose helpers are Python 3+ only (not used on NAO/robot runtimes)."""
+
+        @staticmethod
+        def resolve_compose_path(path, caller_file=None):
+            raise RuntimeError(
+                "services_compose requires Python 3 (not available on this device)."
+            )
+
+        @staticmethod
+        def compose_project_name(compose_path, override=None):
+            return ""
+
+        @staticmethod
+        def start(*args, **kwargs):
+            pass
+
+        @staticmethod
+        def start_service_monitor(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def stop_running():
+            pass
+
+    sic_compose = _ComposeStub()
 
 class SICApplication(object):
     """
@@ -110,6 +140,10 @@ class SICApplication(object):
 
     def _start_services_compose(self, services_compose, caller_file):
         """Resolve, start, and monitor the demo docker-compose stack."""
+        if sys.version_info[0] < 3:
+            raise RuntimeError(
+                "services_compose requires Python 3 (not available on this device)."
+            )
         compose_path = sic_compose.resolve_compose_path(
             services_compose, caller_file=caller_file
         )

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -1,0 +1,140 @@
+"""
+Docker Compose lifecycle helpers for SICApplication.
+
+Starts and stops per-demo service stacks declared in a docker-compose.yml file.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import shutil
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+
+DOCKER_NOT_INSTALLED_MESSAGE = (
+    "Docker is not installed or not on PATH. Install Docker Desktop to use "
+    "services_compose, or start required services manually."
+)
+
+
+def resolve_compose_path(path: str, caller_file: Optional[str] = None) -> Path:
+    """
+    Resolve ``path`` relative to the caller's source directory.
+
+    If ``path`` is already absolute, it is returned as-is.
+    """
+    compose_path = Path(path)
+    if compose_path.is_absolute():
+        resolved = compose_path.resolve()
+    else:
+        if not caller_file:
+            frame = inspect.currentframe()
+            try:
+                caller = frame.f_back if frame else None
+                caller_file = caller.f_globals.get("__file__") if caller else None
+            finally:
+                del frame
+        if not caller_file:
+            raise RuntimeError(
+                "Could not resolve services_compose path; pass an absolute path or "
+                "call from demo module code."
+            )
+        base = Path(caller_file).resolve().parent
+        resolved = (base / path).resolve()
+
+    if not resolved.is_file():
+        raise IOError("Docker Compose file not found: {}".format(resolved))
+    return resolved
+
+
+def default_project_name(compose_path: Path) -> str:
+    """Derive a stable compose project name from the compose file location."""
+    slug = compose_path.parent.name.replace("_", "-").lower()
+    return "sic-{}".format(slug)
+
+
+def _docker_compose_base_cmd() -> list[str]:
+    if shutil.which("docker") is None:
+        raise RuntimeError(DOCKER_NOT_INSTALLED_MESSAGE)
+    return ["docker", "compose"]
+
+
+def _wait_for_tcp(host: str, port: int, timeout_sec: float = 60.0) -> None:
+    deadline = time.time() + timeout_sec
+    last_err = None
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=2.0):
+                return
+        except OSError as exc:
+            last_err = exc
+            time.sleep(0.4)
+    raise RuntimeError(
+        "Timed out waiting for {host}:{port} ({err})".format(
+            host=host, port=port, err=last_err
+        )
+    )
+
+
+def start(
+    compose_path: Path,
+    project_name: str,
+    host_ip: str,
+    *,
+    redis_host: str = "127.0.0.1",
+    redis_port: int = 6379,
+    startup_timeout_sec: float = 120.0,
+) -> None:
+    """
+    Build and start the compose stack, then wait until Redis is reachable on the host.
+    """
+    env = os.environ.copy()
+    env["SIC_HOST_IP"] = host_ip
+
+    cmd = _docker_compose_base_cmd() + [
+        "-f",
+        str(compose_path),
+        "-p",
+        project_name,
+        "up",
+        "-d",
+        "--build",
+        "--wait",
+    ]
+    result = subprocess.run(
+        cmd,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "docker compose up failed (exit {code}):\n{out}\n{err}".format(
+                code=result.returncode,
+                out=(result.stdout or "").strip(),
+                err=(result.stderr or "").strip(),
+            )
+        )
+
+    _wait_for_tcp(redis_host, redis_port, timeout_sec=startup_timeout_sec)
+
+
+def stop(compose_path: Path, project_name: str) -> None:
+    """Stop and remove containers for the compose project."""
+    if shutil.which("docker") is None:
+        return
+
+    cmd = _docker_compose_base_cmd() + [
+        "-f",
+        str(compose_path),
+        "-p",
+        project_name,
+        "down",
+        "--remove-orphans",
+    ]
+    subprocess.run(cmd, capture_output=True, text=True)

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Optional
@@ -90,6 +91,11 @@ def _compose_cmd(compose_path: Path, project_name: str) -> list[str]:
     ]
 
 
+def _notify(message: str) -> None:
+    """Print a user-facing status line (compose starts before SIC logging is up)."""
+    print(message, file=sys.stderr, flush=True)
+
+
 def _run_compose(cmd: list[str], env: dict[str, str], action: str) -> None:
     result = subprocess.run(cmd, env=env, capture_output=True, text=True)
     if result.returncode != 0:
@@ -120,6 +126,16 @@ def start(
 
     base = _compose_cmd(compose_path, project_name)
 
+    _notify(
+        "Starting background services from {} (project: {})...".format(
+            compose_path.name, project_name
+        )
+    )
+    _notify(
+        "Hold tight — the first run builds Docker images and can take a few minutes."
+    )
+
+    _notify("Building shared sic-base image...")
     # Build shared sic-base image before service images that FROM sic-base:local.
     _run_compose(
         base + ["--profile", "build", "build", "sic-base"],
@@ -127,9 +143,11 @@ def start(
         "build (sic-base)",
     )
 
+    _notify("Building and starting service containers...")
     _run_compose(base + ["up", "-d", "--build", "--wait"], env, "up")
 
     _wait_for_tcp(redis_host, redis_port, timeout_sec=startup_timeout_sec)
+    _notify("Background services are ready.")
 
 
 def stop(compose_path: Path, project_name: str) -> None:

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -81,6 +81,28 @@ def _wait_for_tcp(host: str, port: int, timeout_sec: float = 60.0) -> None:
     )
 
 
+def _compose_cmd(compose_path: Path, project_name: str) -> list[str]:
+    return _docker_compose_base_cmd() + [
+        "-f",
+        str(compose_path),
+        "-p",
+        project_name,
+    ]
+
+
+def _run_compose(cmd: list[str], env: dict[str, str], action: str) -> None:
+    result = subprocess.run(cmd, env=env, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            "docker compose {action} failed (exit {code}):\n{out}\n{err}".format(
+                action=action,
+                code=result.returncode,
+                out=(result.stdout or "").strip(),
+                err=(result.stderr or "").strip(),
+            )
+        )
+
+
 def start(
     compose_path: Path,
     project_name: str,
@@ -96,30 +118,16 @@ def start(
     env = os.environ.copy()
     env["SIC_HOST_IP"] = host_ip
 
-    cmd = _docker_compose_base_cmd() + [
-        "-f",
-        str(compose_path),
-        "-p",
-        project_name,
-        "up",
-        "-d",
-        "--build",
-        "--wait",
-    ]
-    result = subprocess.run(
-        cmd,
-        env=env,
-        capture_output=True,
-        text=True,
+    base = _compose_cmd(compose_path, project_name)
+
+    # Build shared sic-base image before service images that FROM sic-base:local.
+    _run_compose(
+        base + ["--profile", "build", "build", "sic-base"],
+        env,
+        "build (sic-base)",
     )
-    if result.returncode != 0:
-        raise RuntimeError(
-            "docker compose up failed (exit {code}):\n{out}\n{err}".format(
-                code=result.returncode,
-                out=(result.stdout or "").strip(),
-                err=(result.stderr or "").strip(),
-            )
-        )
+
+    _run_compose(base + ["up", "-d", "--build", "--wait"], env, "up")
 
     _wait_for_tcp(redis_host, redis_port, timeout_sec=startup_timeout_sec)
 
@@ -129,11 +137,7 @@ def stop(compose_path: Path, project_name: str) -> None:
     if shutil.which("docker") is None:
         return
 
-    cmd = _docker_compose_base_cmd() + [
-        "-f",
-        str(compose_path),
-        "-p",
-        project_name,
+    cmd = _compose_cmd(compose_path, project_name) + [
         "down",
         "--remove-orphans",
     ]

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -22,6 +22,105 @@ DOCKER_NOT_INSTALLED_MESSAGE = (
     "services_compose, or start required services manually."
 )
 
+DOCKER_ROOT_MISSING_MESSAGE = (
+    "Docker files not found in the installed social-interaction-cloud package. "
+    "Reinstall or upgrade the package, set SIC_DOCKER_ROOT manually, or use "
+    "pre-built images in your compose file."
+)
+
+
+def _sic_framework_dir() -> Path:
+    import sic_framework
+
+    return Path(sic_framework.__file__).resolve().parent
+
+
+def resolve_docker_root() -> Path:
+    """
+    Return the directory containing shipped Docker files (``sic_framework/docker/``).
+
+    Uses ``SIC_DOCKER_ROOT`` when set, otherwise derives the path from the installed
+    ``sic_framework`` package location.
+    """
+    override = os.environ.get("SIC_DOCKER_ROOT")
+    if override:
+        root = Path(override).expanduser().resolve()
+    else:
+        root = _sic_framework_dir()
+
+    dockerfile = root / "docker" / "sic-base" / "Dockerfile"
+    if not dockerfile.is_file():
+        legacy = root.parent / "docker" / "sic-base" / "Dockerfile"
+        if legacy.is_file():
+            return root.parent
+        raise RuntimeError(DOCKER_ROOT_MISSING_MESSAGE)
+    return root
+
+
+def resolve_build_context(docker_root: Optional[Path] = None) -> Path:
+    """
+    Return the Docker build context for service images.
+
+    Source checkouts use the repo root (parent of ``sic_framework/``) so local
+    ``COPY`` installs work. PyPI installs use the package directory (PyPI target
+    ignores context).
+    """
+    override = os.environ.get("SIC_BUILD_CONTEXT")
+    if override:
+        return Path(override).expanduser().resolve()
+
+    docker_root = docker_root or resolve_docker_root()
+    repo_root = docker_root.parent
+    if (repo_root / "setup.py").is_file():
+        return repo_root.resolve()
+    return docker_root
+
+
+def resolve_build_target(docker_root: Optional[Path] = None) -> str:
+    """Return ``local`` for source checkouts, ``pypi`` for PyPI-only installs."""
+    override = os.environ.get("SIC_BUILD_TARGET")
+    if override:
+        return override
+
+    docker_root = docker_root or resolve_docker_root()
+    repo_root = docker_root.parent
+    if (repo_root / "setup.py").is_file():
+        return "local"
+    return "pypi"
+
+
+def resolve_sic_version() -> str:
+    override = os.environ.get("SIC_VERSION")
+    if override:
+        return override
+
+    try:
+        from importlib.metadata import version
+
+        return version("social-interaction-cloud")
+    except Exception:
+        pass
+
+    setup_py = _sic_framework_dir().parent / "setup.py"
+    if setup_py.is_file():
+        for line in setup_py.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("version="):
+                return stripped.split("=", 1)[1].strip().strip('"').strip("'").rstrip(",")
+    return "2.2.3"
+
+
+def _compose_env(host_ip: Optional[str] = None) -> dict[str, str]:
+    env = os.environ.copy()
+    docker_root = resolve_docker_root()
+    env["SIC_DOCKER_ROOT"] = str(docker_root)
+    env["SIC_BUILD_CONTEXT"] = str(resolve_build_context(docker_root))
+    env["SIC_BUILD_TARGET"] = resolve_build_target(docker_root)
+    env["SIC_VERSION"] = resolve_sic_version()
+    if host_ip is not None:
+        env["SIC_HOST_IP"] = host_ip
+    return env
+
 
 def resolve_compose_path(path: str, caller_file: Optional[str] = None) -> Path:
     """
@@ -100,10 +199,16 @@ def _wait_for_tcp(host: str, port: int, timeout_sec: float = 60.0) -> None:
     )
 
 
+def _compose_file_paths(compose_path: Path) -> list[str]:
+    return [str(compose_path)]
+
+
 def _compose_cmd(
     compose_path: Path, project_name: Optional[str] = None
 ) -> list[str]:
-    cmd = _docker_compose_base_cmd() + ["-f", str(compose_path)]
+    cmd = _docker_compose_base_cmd()
+    for compose_file in _compose_file_paths(compose_path):
+        cmd.extend(["-f", compose_file])
     if project_name:
         cmd.extend(["-p", project_name])
     return cmd
@@ -200,8 +305,7 @@ def start(
     The compose project name comes from the top-level ``name:`` field in the compose
     file unless ``project_name`` is passed to override it.
     """
-    env = os.environ.copy()
-    env["SIC_HOST_IP"] = host_ip
+    env = _compose_env(host_ip)
 
     display_name = compose_project_name(compose_path, project_name)
     base = _compose_cmd(compose_path, project_name)
@@ -235,4 +339,4 @@ def stop(compose_path: Path, project_name: Optional[str] = None) -> None:
         "down",
         "--remove-orphans",
     ]
-    subprocess.run(cmd, capture_output=True, text=True)
+    subprocess.run(cmd, env=_compose_env(), capture_output=True, text=True)

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -109,7 +109,11 @@ def resolve_sic_version() -> str:
             stripped = line.strip()
             if stripped.startswith("version="):
                 return stripped.split("=", 1)[1].strip().strip('"').strip("'").rstrip(",")
-    return "2.2.3"
+
+    raise RuntimeError(
+        "Could not determine social-interaction-cloud version. Install the package, "
+        "set SIC_VERSION, or run via SICApplication (which sets it automatically)."
+    )
 
 
 def _compose_env(host_ip: Optional[str] = None) -> dict[str, str]:

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -244,8 +244,34 @@ def _rebuild_requested() -> bool:
     )
 
 
-def _service_image_names(project_name: str) -> list[str]:
-    return ["{}-{}".format(project_name, svc) for svc in ("gpt", "datastore")]
+def _buildable_services(base: list[str], env: dict[str, str]) -> list[str]:
+    """Return compose service names that declare a ``build`` section (excluding sic-base)."""
+    result = subprocess.run(
+        base + ["config", "--format", "json"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "docker compose config failed (exit {code}):\n{out}\n{err}".format(
+                code=result.returncode,
+                out=(result.stdout or "").strip(),
+                err=(result.stderr or "").strip(),
+            )
+        )
+
+    config = json.loads(result.stdout)
+    services = config.get("services") or {}
+    return [
+        name
+        for name, service in services.items()
+        if name != "sic-base" and service.get("build") is not None
+    ]
+
+
+def _service_image_names(project_name: str, service_names: list[str]) -> list[str]:
+    return ["{}-{}".format(project_name, svc) for svc in service_names]
 
 
 def _ensure_images(
@@ -270,14 +296,18 @@ def _ensure_images(
         )
         built = True
 
-    missing_services = [
+    buildable = _buildable_services(base, env)
+    if not buildable:
+        return built
+
+    missing_images = [
         img
-        for img in _service_image_names(project_name)
+        for img in _service_image_names(project_name, buildable)
         if rebuild or not _image_exists(img)
     ]
-    if missing_services:
-        _notify("Building service images ({})...".format(", ".join(missing_services)))
-        _run_compose(base + ["build", "gpt", "datastore"], env, "build")
+    if missing_images:
+        _notify("Building service images ({})...".format(", ".join(missing_images)))
+        _run_compose(base + ["build"] + buildable, env, "build")
         built = True
 
     return built
@@ -330,7 +360,11 @@ def start(
     else:
         _notify("Using existing Docker images, starting containers...")
 
-    _run_compose(base + ["up", "-d", "--wait"], env, "up")
+    try:
+        _run_compose(base + ["up", "-d", "--wait"], env, "up")
+    except RuntimeError:
+        stop(compose_path, project_name)
+        raise
 
     _wait_for_tcp(redis_host, redis_port, timeout_sec=startup_timeout_sec)
     _notify("Background services are ready.")

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -30,7 +30,7 @@ DOCKER_ROOT_MISSING_MESSAGE = (
     "pre-built images in your compose file."
 )
 
-# Set by start(), cleared by stop_running() — used so shutdown always finds the stack.
+# Set by start(), cleared by stop_running() - used so shutdown always finds the stack.
 _running_stack: Optional[tuple[Path, str, str]] = None
 
 
@@ -377,7 +377,7 @@ def start(
     built = _ensure_images(base, env, resolved_project)
     if built:
         _notify(
-            "Hold tight — building Docker images can take a few minutes on first run."
+            "Hold tight - building Docker images can take a few minutes on first run."
         )
     else:
         _notify("Using existing Docker images, starting containers...")

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -1,7 +1,49 @@
 """
 Docker Compose lifecycle helpers for SICApplication.
 
-Starts and stops per-demo service stacks declared in a docker-compose.yml file.
+Starts and stops per-demo service stacks declared in a demo's ``docker-compose.yml``.
+Used by ``SICApplication._start_services_compose`` / ``_stop_services_compose``.
+
+Call graph (entry points from ``sic_application`` in **bold**):
+
+::
+
+    **resolve_compose_path**
+        (optional: inspect stack for caller ``__file__``)
+
+    **start**
+        |-- compose_project_name --> default_project_name (fallback)
+        |-- _compose_env
+        |       |-- resolve_docker_root --> _sic_framework_dir
+        |       |-- resolve_build_context --> resolve_docker_root
+        |       |-- resolve_build_target --> resolve_docker_root
+        |       +-- resolve_sic_version --> _sic_framework_dir
+        |-- _compose_cmd --> _docker_compose_base_cmd
+        |                 --> _compose_file_paths
+        |-- _ensure_images
+        |       |-- _rebuild_requested
+        |       |-- _image_exists
+        |       |-- _buildable_services --> _run_compose (config)
+        |       |-- _service_image_names
+        |       +-- _run_compose (build sic-base / services)
+        |-- _run_compose (up -d --wait)
+        |-- on failure: **stop**
+        +-- _wait_for_tcp (Redis on host)
+
+    **stop**
+        |-- _compose_cmd
+        +-- _compose_env
+
+    **start_service_monitor** --> ComposeServiceMonitor.start --> _run (daemon thread)
+        +-- check_service_errors (poll loop)
+                |-- _compose_cmd, _compose_env
+                |-- _parse_compose_ps_json
+                +-- _fetch_service_logs --> _monitor_log_tail
+
+Environment variables
+---------------------
+SIC_DOCKER_ROOT, SIC_BUILD_CONTEXT, SIC_BUILD_TARGET, SIC_VERSION, SIC_HOST_IP,
+SIC_COMPOSE_REBUILD, SIC_COMPOSE_MONITOR_INTERVAL, SIC_COMPOSE_MONITOR_LOG_TAIL
 """
 
 from __future__ import annotations
@@ -32,6 +74,7 @@ DOCKER_ROOT_MISSING_MESSAGE = (
 
 
 def _sic_framework_dir() -> Path:
+    """Return the installed ``sic_framework`` package directory (contains ``docker/``)."""
     import sic_framework
 
     return Path(sic_framework.__file__).resolve().parent
@@ -52,6 +95,7 @@ def resolve_docker_root() -> Path:
 
     dockerfile = root / "docker" / "sic-base" / "Dockerfile"
     if not dockerfile.is_file():
+        # Older layouts kept docker/ at the repo root instead of sic_framework/docker/.
         legacy = root.parent / "docker" / "sic-base" / "Dockerfile"
         if legacy.is_file():
             return root.parent
@@ -92,6 +136,12 @@ def resolve_build_target(docker_root: Optional[Path] = None) -> str:
 
 
 def resolve_sic_version() -> str:
+    """
+    Return the installed ``social-interaction-cloud`` package version string.
+
+    Uses ``SIC_VERSION`` when set, otherwise ``importlib.metadata``, then parses
+    ``setup.py`` for editable/source checkouts.
+    """
     override = os.environ.get("SIC_VERSION")
     if override:
         return override
@@ -117,6 +167,16 @@ def resolve_sic_version() -> str:
 
 
 def _compose_env(host_ip: Optional[str] = None) -> dict[str, str]:
+    """
+    Return a copy of the current environment with SIC Docker-related variables set.
+
+    Adds:
+      - SIC_DOCKER_ROOT: Path to the Docker root directory of the repo.
+      - SIC_BUILD_CONTEXT: Path to the build context (usually repo root).
+      - SIC_BUILD_TARGET: "local" for source checkouts, "pypi" for PyPI installs.
+      - SIC_VERSION: The SIC package version.
+      - SIC_HOST_IP: The given host IP if provided.
+    """
     env = os.environ.copy()
     docker_root = resolve_docker_root()
     env["SIC_DOCKER_ROOT"] = str(docker_root)
@@ -183,12 +243,18 @@ def default_project_name(compose_path: Path) -> str:
 
 
 def _docker_compose_base_cmd() -> list[str]:
+    """Return ``['docker', 'compose']`` or raise if Docker is not on PATH."""
     if shutil.which("docker") is None:
         raise RuntimeError(DOCKER_NOT_INSTALLED_MESSAGE)
     return ["docker", "compose"]
 
 
 def _wait_for_tcp(host: str, port: int, timeout_sec: float = 60.0) -> None:
+    """
+    Block until ``host:port`` accepts a TCP connection.
+
+    Used after ``compose up`` so the demo can connect to Redis published on the host.
+    """
     deadline = time.time() + timeout_sec
     last_err = None
     while time.time() < deadline:
@@ -206,12 +272,18 @@ def _wait_for_tcp(host: str, port: int, timeout_sec: float = 60.0) -> None:
 
 
 def _compose_file_paths(compose_path: Path) -> list[str]:
+    """Return compose file path(s) for repeated ``-f`` flags (single file today)."""
     return [str(compose_path)]
 
 
 def _compose_cmd(
     compose_path: Path, project_name: Optional[str] = None
 ) -> list[str]:
+    """
+    Build a ``docker compose`` argv prefix: base command, ``-f`` file(s), optional ``-p``.
+
+    Does not include subcommands (``up``, ``down``, ``ps``, etc.).
+    """
     cmd = _docker_compose_base_cmd()
     for compose_file in _compose_file_paths(compose_path):
         cmd.extend(["-f", compose_file])
@@ -226,6 +298,7 @@ def _notify(message: str) -> None:
 
 
 def _image_exists(image_ref: str) -> bool:
+    """Return True if ``docker image inspect`` succeeds for the given reference."""
     ref = image_ref if ":" in image_ref else image_ref + ":latest"
     return (
         subprocess.run(
@@ -237,6 +310,7 @@ def _image_exists(image_ref: str) -> bool:
 
 
 def _rebuild_requested() -> bool:
+    """Return True when ``SIC_COMPOSE_REBUILD`` is set to a truthy value."""
     return os.environ.get("SIC_COMPOSE_REBUILD", "").lower() in (
         "1",
         "true",
@@ -271,6 +345,11 @@ def _buildable_services(base: list[str], env: dict[str, str]) -> list[str]:
 
 
 def _service_image_names(project_name: str, service_names: list[str]) -> list[str]:
+    """
+    Map compose service names to local image tags Docker Compose assigns.
+
+    Compose names images ``{project}-{service}`` (no registry prefix).
+    """
     return ["{}-{}".format(project_name, svc) for svc in service_names]
 
 
@@ -287,6 +366,7 @@ def _ensure_images(
     built = False
     rebuild = _rebuild_requested()
 
+    # sic-base is built via the compose "build" profile, not as a runtime service.
     if rebuild or not _image_exists("sic-base:local"):
         _notify("Building shared sic-base image...")
         _run_compose(
@@ -314,6 +394,7 @@ def _ensure_images(
 
 
 def _run_compose(cmd: list[str], env: dict[str, str], action: str) -> None:
+    """Run a full ``docker compose`` command; raise ``RuntimeError`` on non-zero exit."""
     result = subprocess.run(cmd, env=env, capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError(
@@ -361,17 +442,24 @@ def start(
         _notify("Using existing Docker images, starting containers...")
 
     try:
+        # --wait blocks until healthchecks pass (when defined in the compose file).
         _run_compose(base + ["up", "-d", "--wait"], env, "up")
     except RuntimeError:
+        # Avoid leaving a half-started stack if up fails mid-way.
         stop(compose_path, project_name)
         raise
 
+    # Redis is published on the host; confirm the port is open before returning.
     _wait_for_tcp(redis_host, redis_port, timeout_sec=startup_timeout_sec)
     _notify("Background services are ready.")
 
 
 def stop(compose_path: Path, project_name: Optional[str] = None) -> None:
-    """Stop and remove containers for the compose project."""
+    """
+    Stop and remove containers for the compose project.
+
+    No-op when Docker is not installed (cleanup during partial setup).
+    """
     if shutil.which("docker") is None:
         return
 
@@ -383,6 +471,7 @@ def stop(compose_path: Path, project_name: Optional[str] = None) -> None:
 
 
 def _monitor_poll_interval_sec() -> float:
+    """Poll interval for ``ComposeServiceMonitor`` (``SIC_COMPOSE_MONITOR_INTERVAL``)."""
     raw = os.environ.get("SIC_COMPOSE_MONITOR_INTERVAL", "3.0")
     try:
         return max(0.5, float(raw))
@@ -391,6 +480,7 @@ def _monitor_poll_interval_sec() -> float:
 
 
 def _monitor_log_tail() -> int:
+    """Number of log lines to attach to monitor error messages."""
     raw = os.environ.get("SIC_COMPOSE_MONITOR_LOG_TAIL", "25")
     try:
         return max(5, int(raw))
@@ -399,6 +489,7 @@ def _monitor_log_tail() -> int:
 
 
 def _parse_compose_ps_json(stdout: str) -> list[dict]:
+    """Parse newline-delimited JSON objects from ``docker compose ps --format json``."""
     entries = []
     for line in stdout.splitlines():
         stripped = line.strip()
@@ -416,6 +507,7 @@ def _fetch_service_logs(
     tail: int,
     host_ip: Optional[str] = None,
 ) -> str:
+    """Fetch recent logs for the given service names (used in error reports)."""
     if not services:
         return ""
     cmd = _compose_cmd(compose_path, project_name) + [
@@ -455,6 +547,7 @@ def check_service_errors(
 
     for entry in _parse_compose_ps_json(result.stdout):
         service = entry.get("Service") or entry.get("Name") or "unknown"
+        # sic-base is build-only; it never appears as a long-running container.
         if service == "sic-base":
             continue
 
@@ -502,7 +595,11 @@ def check_service_errors(
 
 
 class ComposeServiceMonitor(object):
-    """Background poll of ``docker compose ps`` for exited/unhealthy services."""
+    """
+    Background poll of ``docker compose ps`` for exited/unhealthy services.
+
+    On failure, invokes ``on_error`` once and exits the monitor thread.
+    """
 
     def __init__(
         self,
@@ -512,6 +609,13 @@ class ComposeServiceMonitor(object):
         on_error: Callable[[Exception], None],
         poll_interval_sec: Optional[float] = None,
     ):
+        """
+        :param compose_path: Resolved path to the demo compose file.
+        :param project_name: Optional ``-p`` override (usually ``None``; use compose ``name:``).
+        :param host_ip: Host IP passed through to compose env for log commands.
+        :param on_error: Callback (e.g. ``SICApplication.report_background_exception``).
+        :param poll_interval_sec: Override default poll interval from env.
+        """
         self._compose_path = compose_path
         self._project_name = project_name
         self._host_ip = host_ip
@@ -525,6 +629,7 @@ class ComposeServiceMonitor(object):
         self._thread = None
 
     def start(self) -> None:
+        """Start the daemon polling thread."""
         self._stop_event.clear()
         self._thread = threading.Thread(
             target=self._run,
@@ -534,11 +639,13 @@ class ComposeServiceMonitor(object):
         self._thread.start()
 
     def stop(self, timeout_sec: float = 5.0) -> None:
+        """Signal the monitor to exit and wait for the thread to finish."""
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join(timeout=timeout_sec)
 
     def _run(self) -> None:
+        """Poll ``check_service_errors`` until shutdown or a failure is reported."""
         while not self._stop_event.is_set():
             try:
                 error = check_service_errors(
@@ -560,7 +667,11 @@ def start_service_monitor(
     host_ip: str,
     on_error: Callable[[Exception], None],
 ) -> ComposeServiceMonitor:
-    """Start a daemon thread that reports compose service failures via ``on_error``."""
+    """
+    Create a ``ComposeServiceMonitor`` and start its daemon thread.
+
+    See module docstring for how this fits into the overall call graph.
+    """
     monitor = ComposeServiceMonitor(compose_path, project_name, host_ip, on_error)
     monitor.start()
     return monitor

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -7,14 +7,16 @@ Starts and stops per-demo service stacks declared in a docker-compose.yml file.
 from __future__ import annotations
 
 import inspect
+import json
 import os
 import shutil
 import socket
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 
 DOCKER_NOT_INSTALLED_MESSAGE = (
@@ -340,3 +342,187 @@ def stop(compose_path: Path, project_name: Optional[str] = None) -> None:
         "--remove-orphans",
     ]
     subprocess.run(cmd, env=_compose_env(), capture_output=True, text=True)
+
+
+def _monitor_poll_interval_sec() -> float:
+    raw = os.environ.get("SIC_COMPOSE_MONITOR_INTERVAL", "3.0")
+    try:
+        return max(0.5, float(raw))
+    except ValueError:
+        return 3.0
+
+
+def _monitor_log_tail() -> int:
+    raw = os.environ.get("SIC_COMPOSE_MONITOR_LOG_TAIL", "25")
+    try:
+        return max(5, int(raw))
+    except ValueError:
+        return 25
+
+
+def _parse_compose_ps_json(stdout: str) -> list[dict]:
+    entries = []
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        entries.append(json.loads(stripped))
+    return entries
+
+
+def _fetch_service_logs(
+    compose_path: Path,
+    project_name: Optional[str],
+    services: list[str],
+    *,
+    tail: int,
+    host_ip: Optional[str] = None,
+) -> str:
+    if not services:
+        return ""
+    cmd = _compose_cmd(compose_path, project_name) + [
+        "logs",
+        "--no-color",
+        "--tail={}".format(tail),
+    ] + services
+    result = subprocess.run(
+        cmd, env=_compose_env(host_ip), capture_output=True, text=True
+    )
+    output = (result.stdout or "") + (result.stderr or "")
+    return output.strip()
+
+
+def check_service_errors(
+    compose_path: Path,
+    project_name: Optional[str] = None,
+    host_ip: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Return a descriptive error if any compose service is exited or unhealthy.
+
+    Returns ``None`` when all monitored services look healthy.
+    """
+    if shutil.which("docker") is None:
+        return None
+
+    cmd = _compose_cmd(compose_path, project_name) + ["ps", "-a", "--format", "json"]
+    result = subprocess.run(cmd, env=_compose_env(host_ip), capture_output=True, text=True)
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "").strip()
+        return "Failed to inspect compose services: {}".format(err or result.returncode)
+
+    problems = []
+    problem_services = []
+    ok_states = {"running", "created"}
+
+    for entry in _parse_compose_ps_json(result.stdout):
+        service = entry.get("Service") or entry.get("Name") or "unknown"
+        if service == "sic-base":
+            continue
+
+        state = (entry.get("State") or "").lower()
+        health = (entry.get("Health") or "").lower()
+        exit_code = entry.get("ExitCode")
+
+        if state == "exited":
+            problems.append(
+                "{service} exited (code {code})".format(
+                    service=service, code=exit_code
+                )
+            )
+            problem_services.append(service)
+        elif health == "unhealthy":
+            problems.append("{service} is unhealthy".format(service=service))
+            problem_services.append(service)
+        elif state in ("dead", "restarting"):
+            problems.append(
+                "{service} is {state}".format(service=service, state=state)
+            )
+            problem_services.append(service)
+        elif state and state not in ok_states:
+            problems.append(
+                "{service} is in unexpected state '{state}'".format(
+                    service=service, state=state
+                )
+            )
+            problem_services.append(service)
+
+    if not problems:
+        return None
+
+    logs = _fetch_service_logs(
+        compose_path,
+        project_name,
+        problem_services,
+        tail=_monitor_log_tail(),
+        host_ip=host_ip,
+    )
+    message = "Docker compose service failure:\n- " + "\n- ".join(problems)
+    if logs:
+        message += "\n\nRecent service logs:\n{}".format(logs)
+    return message
+
+
+class ComposeServiceMonitor(object):
+    """Background poll of ``docker compose ps`` for exited/unhealthy services."""
+
+    def __init__(
+        self,
+        compose_path: Path,
+        project_name: Optional[str],
+        host_ip: str,
+        on_error: Callable[[Exception], None],
+        poll_interval_sec: Optional[float] = None,
+    ):
+        self._compose_path = compose_path
+        self._project_name = project_name
+        self._host_ip = host_ip
+        self._on_error = on_error
+        self._poll_interval_sec = (
+            poll_interval_sec
+            if poll_interval_sec is not None
+            else _monitor_poll_interval_sec()
+        )
+        self._stop_event = threading.Event()
+        self._thread = None
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="sic-compose-monitor",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, timeout_sec: float = 5.0) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout_sec)
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                error = check_service_errors(
+                    self._compose_path, self._project_name, self._host_ip
+                )
+                if error and not self._stop_event.is_set():
+                    self._on_error(RuntimeError(error))
+                    return
+            except Exception as exc:
+                if not self._stop_event.is_set():
+                    self._on_error(exc)
+                    return
+            self._stop_event.wait(self._poll_interval_sec)
+
+
+def start_service_monitor(
+    compose_path: Path,
+    project_name: Optional[str],
+    host_ip: str,
+    on_error: Callable[[Exception], None],
+) -> ComposeServiceMonitor:
+    """Start a daemon thread that reports compose service failures via ``on_error``."""
+    monitor = ComposeServiceMonitor(compose_path, project_name, host_ip, on_error)
+    monitor.start()
+    return monitor

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -1,49 +1,7 @@
 """
 Docker Compose lifecycle helpers for SICApplication.
 
-Starts and stops per-demo service stacks declared in a demo's ``docker-compose.yml``.
-Used by ``SICApplication._start_services_compose`` / ``_stop_services_compose``.
-
-Call graph (entry points from ``sic_application`` in **bold**):
-
-::
-
-    **resolve_compose_path**
-        (optional: inspect stack for caller ``__file__``)
-
-    **start**
-        |-- compose_project_name --> default_project_name (fallback)
-        |-- _compose_env
-        |       |-- resolve_docker_root --> _sic_framework_dir
-        |       |-- resolve_build_context --> resolve_docker_root
-        |       |-- resolve_build_target --> resolve_docker_root
-        |       +-- resolve_sic_version --> _sic_framework_dir
-        |-- _compose_cmd --> _docker_compose_base_cmd
-        |                 --> _compose_file_paths
-        |-- _ensure_images
-        |       |-- _rebuild_requested
-        |       |-- _image_exists
-        |       |-- _buildable_services --> _run_compose (config)
-        |       |-- _service_image_names
-        |       +-- _run_compose (build sic-base / services)
-        |-- _run_compose (up -d --wait)
-        |-- on failure: **stop**
-        +-- _wait_for_tcp (Redis on host)
-
-    **stop**
-        |-- _compose_cmd
-        +-- _compose_env
-
-    **start_service_monitor** --> ComposeServiceMonitor.start --> _run (daemon thread)
-        +-- check_service_errors (poll loop)
-                |-- _compose_cmd, _compose_env
-                |-- _parse_compose_ps_json
-                +-- _fetch_service_logs --> _monitor_log_tail
-
-Environment variables
----------------------
-SIC_DOCKER_ROOT, SIC_BUILD_CONTEXT, SIC_BUILD_TARGET, SIC_VERSION, SIC_HOST_IP,
-SIC_COMPOSE_REBUILD, SIC_COMPOSE_MONITOR_INTERVAL, SIC_COMPOSE_MONITOR_LOG_TAIL
+Starts and stops per-demo stacks from each demo's ``docker-compose.yml``.
 """
 
 from __future__ import annotations
@@ -71,6 +29,9 @@ DOCKER_ROOT_MISSING_MESSAGE = (
     "Reinstall or upgrade the package, set SIC_DOCKER_ROOT manually, or use "
     "pre-built images in your compose file."
 )
+
+# Set by start(), cleared by stop_running() — used so shutdown always finds the stack.
+_running_stack: Optional[tuple[Path, str, str]] = None
 
 
 def _sic_framework_dir() -> Path:
@@ -166,25 +127,15 @@ def resolve_sic_version() -> str:
     )
 
 
-def _compose_env(host_ip: Optional[str] = None) -> dict[str, str]:
-    """
-    Return a copy of the current environment with SIC Docker-related variables set.
-
-    Adds:
-      - SIC_DOCKER_ROOT: Path to the Docker root directory of the repo.
-      - SIC_BUILD_CONTEXT: Path to the build context (usually repo root).
-      - SIC_BUILD_TARGET: "local" for source checkouts, "pypi" for PyPI installs.
-      - SIC_VERSION: The SIC package version.
-      - SIC_HOST_IP: The given host IP if provided.
-    """
+def _compose_env(host_ip: str) -> dict[str, str]:
+    """Environment for ``docker compose`` (paths/version for builds, host IP for services)."""
     env = os.environ.copy()
     docker_root = resolve_docker_root()
     env["SIC_DOCKER_ROOT"] = str(docker_root)
     env["SIC_BUILD_CONTEXT"] = str(resolve_build_context(docker_root))
     env["SIC_BUILD_TARGET"] = resolve_build_target(docker_root)
     env["SIC_VERSION"] = resolve_sic_version()
-    if host_ip is not None:
-        env["SIC_HOST_IP"] = host_ip
+    env["SIC_HOST_IP"] = host_ip
     return env
 
 
@@ -271,25 +222,14 @@ def _wait_for_tcp(host: str, port: int, timeout_sec: float = 60.0) -> None:
     )
 
 
-def _compose_file_paths(compose_path: Path) -> list[str]:
-    """Return compose file path(s) for repeated ``-f`` flags (single file today)."""
-    return [str(compose_path)]
-
-
-def _compose_cmd(
-    compose_path: Path, project_name: Optional[str] = None
-) -> list[str]:
-    """
-    Build a ``docker compose`` argv prefix: base command, ``-f`` file(s), optional ``-p``.
-
-    Does not include subcommands (``up``, ``down``, ``ps``, etc.).
-    """
-    cmd = _docker_compose_base_cmd()
-    for compose_file in _compose_file_paths(compose_path):
-        cmd.extend(["-f", compose_file])
-    if project_name:
-        cmd.extend(["-p", project_name])
-    return cmd
+def _compose_cmd(compose_path: Path, project_name: str) -> list[str]:
+    """``docker compose -f <file> -p <project>`` (subcommand added by caller)."""
+    return _docker_compose_base_cmd() + [
+        "-f",
+        str(compose_path),
+        "-p",
+        project_name,
+    ]
 
 
 def _notify(message: str) -> None:
@@ -424,16 +364,17 @@ def start(
     """
     env = _compose_env(host_ip)
 
-    display_name = compose_project_name(compose_path, project_name)
-    base = _compose_cmd(compose_path, project_name)
+    # Always pass -p so up/down/ps target the same project (compose file ``name:`` or override).
+    resolved_project = compose_project_name(compose_path, project_name)
+    base = _compose_cmd(compose_path, resolved_project)
 
     _notify(
         "Starting background services from {} (project: {})...".format(
-            compose_path.name, display_name
+            compose_path.name, resolved_project
         )
     )
 
-    built = _ensure_images(base, env, display_name)
+    built = _ensure_images(base, env, resolved_project)
     if built:
         _notify(
             "Hold tight — building Docker images can take a few minutes on first run."
@@ -442,50 +383,47 @@ def start(
         _notify("Using existing Docker images, starting containers...")
 
     try:
-        # --wait blocks until healthchecks pass (when defined in the compose file).
         _run_compose(base + ["up", "-d", "--wait"], env, "up")
     except RuntimeError:
-        # Avoid leaving a half-started stack if up fails mid-way.
-        stop(compose_path, project_name)
+        stop(compose_path, resolved_project, host_ip)
         raise
 
     # Redis is published on the host; confirm the port is open before returning.
     _wait_for_tcp(redis_host, redis_port, timeout_sec=startup_timeout_sec)
+    global _running_stack
+    _running_stack = (compose_path, resolved_project, host_ip)
     _notify("Background services are ready.")
 
 
-def stop(compose_path: Path, project_name: Optional[str] = None) -> None:
-    """
-    Stop and remove containers for the compose project.
+def stop_running() -> None:
+    """Stop the stack started by ``start()`` (safe to call more than once)."""
+    global _running_stack
+    if _running_stack is None:
+        return
+    compose_path, project_name, host_ip = _running_stack
+    _running_stack = None
+    try:
+        stop(compose_path, project_name, host_ip)
+    except RuntimeError as exc:
+        _notify(str(exc))
 
-    No-op when Docker is not installed (cleanup during partial setup).
-    """
+
+def stop(compose_path: Path, project_name: str, host_ip: str) -> None:
+    """Stop and remove containers for the compose project (no-op if Docker missing)."""
     if shutil.which("docker") is None:
         return
 
-    cmd = _compose_cmd(compose_path, project_name) + [
+    _run_compose(
+        _compose_cmd(compose_path, project_name)
+        + ["down", "--remove-orphans"],
+        _compose_env(host_ip),
         "down",
-        "--remove-orphans",
-    ]
-    subprocess.run(cmd, env=_compose_env(), capture_output=True, text=True)
+    )
+    _notify("Stopped docker compose stack {}.".format(project_name))
 
 
-def _monitor_poll_interval_sec() -> float:
-    """Poll interval for ``ComposeServiceMonitor`` (``SIC_COMPOSE_MONITOR_INTERVAL``)."""
-    raw = os.environ.get("SIC_COMPOSE_MONITOR_INTERVAL", "3.0")
-    try:
-        return max(0.5, float(raw))
-    except ValueError:
-        return 3.0
-
-
-def _monitor_log_tail() -> int:
-    """Number of log lines to attach to monitor error messages."""
-    raw = os.environ.get("SIC_COMPOSE_MONITOR_LOG_TAIL", "25")
-    try:
-        return max(5, int(raw))
-    except ValueError:
-        return 25
+_MONITOR_POLL_SEC = 3.0
+_MONITOR_LOG_TAIL = 25
 
 
 def _parse_compose_ps_json(stdout: str) -> list[dict]:
@@ -501,11 +439,9 @@ def _parse_compose_ps_json(stdout: str) -> list[dict]:
 
 def _fetch_service_logs(
     compose_path: Path,
-    project_name: Optional[str],
+    project_name: str,
+    host_ip: str,
     services: list[str],
-    *,
-    tail: int,
-    host_ip: Optional[str] = None,
 ) -> str:
     """Fetch recent logs for the given service names (used in error reports)."""
     if not services:
@@ -513,7 +449,7 @@ def _fetch_service_logs(
     cmd = _compose_cmd(compose_path, project_name) + [
         "logs",
         "--no-color",
-        "--tail={}".format(tail),
+        "--tail={}".format(_MONITOR_LOG_TAIL),
     ] + services
     result = subprocess.run(
         cmd, env=_compose_env(host_ip), capture_output=True, text=True
@@ -523,9 +459,7 @@ def _fetch_service_logs(
 
 
 def check_service_errors(
-    compose_path: Path,
-    project_name: Optional[str] = None,
-    host_ip: Optional[str] = None,
+    compose_path: Path, project_name: str, host_ip: str
 ) -> Optional[str]:
     """
     Return a descriptive error if any compose service is exited or unhealthy.
@@ -582,11 +516,7 @@ def check_service_errors(
         return None
 
     logs = _fetch_service_logs(
-        compose_path,
-        project_name,
-        problem_services,
-        tail=_monitor_log_tail(),
-        host_ip=host_ip,
+        compose_path, project_name, host_ip, problem_services
     )
     message = "Docker compose service failure:\n- " + "\n- ".join(problems)
     if logs:
@@ -595,36 +525,19 @@ def check_service_errors(
 
 
 class ComposeServiceMonitor(object):
-    """
-    Background poll of ``docker compose ps`` for exited/unhealthy services.
-
-    On failure, invokes ``on_error`` once and exits the monitor thread.
-    """
+    """Daemon thread: poll ``docker compose ps`` and report exited/unhealthy services."""
 
     def __init__(
         self,
         compose_path: Path,
-        project_name: Optional[str],
+        project_name: str,
         host_ip: str,
         on_error: Callable[[Exception], None],
-        poll_interval_sec: Optional[float] = None,
     ):
-        """
-        :param compose_path: Resolved path to the demo compose file.
-        :param project_name: Optional ``-p`` override (usually ``None``; use compose ``name:``).
-        :param host_ip: Host IP passed through to compose env for log commands.
-        :param on_error: Callback (e.g. ``SICApplication.report_background_exception``).
-        :param poll_interval_sec: Override default poll interval from env.
-        """
         self._compose_path = compose_path
         self._project_name = project_name
         self._host_ip = host_ip
         self._on_error = on_error
-        self._poll_interval_sec = (
-            poll_interval_sec
-            if poll_interval_sec is not None
-            else _monitor_poll_interval_sec()
-        )
         self._stop_event = threading.Event()
         self._thread = None
 
@@ -658,20 +571,16 @@ class ComposeServiceMonitor(object):
                 if not self._stop_event.is_set():
                     self._on_error(exc)
                     return
-            self._stop_event.wait(self._poll_interval_sec)
+            self._stop_event.wait(_MONITOR_POLL_SEC)
 
 
 def start_service_monitor(
     compose_path: Path,
-    project_name: Optional[str],
+    project_name: str,
     host_ip: str,
     on_error: Callable[[Exception], None],
 ) -> ComposeServiceMonitor:
-    """
-    Create a ``ComposeServiceMonitor`` and start its daemon thread.
-
-    See module docstring for how this fits into the overall call graph.
-    """
+    """Start a daemon thread that reports compose service failures via ``on_error``."""
     monitor = ComposeServiceMonitor(compose_path, project_name, host_ip, on_error)
     monitor.start()
     return monitor

--- a/sic_framework/core/sic_compose.py
+++ b/sic_framework/core/sic_compose.py
@@ -53,6 +53,24 @@ def resolve_compose_path(path: str, caller_file: Optional[str] = None) -> Path:
     return resolved
 
 
+def compose_project_name(
+    compose_path: Path, override: Optional[str] = None
+) -> str:
+    """
+    Return the Docker Compose project name for status messages.
+
+    Uses ``override`` when provided, otherwise the top-level ``name:`` field in
+    the compose file, otherwise a name derived from the compose directory.
+    """
+    if override:
+        return override
+    for line in compose_path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("name:"):
+            return stripped.split(":", 1)[1].strip().strip("'\"")
+    return default_project_name(compose_path)
+
+
 def default_project_name(compose_path: Path) -> str:
     """Derive a stable compose project name from the compose file location."""
     slug = compose_path.parent.name.replace("_", "-").lower()
@@ -82,18 +100,76 @@ def _wait_for_tcp(host: str, port: int, timeout_sec: float = 60.0) -> None:
     )
 
 
-def _compose_cmd(compose_path: Path, project_name: str) -> list[str]:
-    return _docker_compose_base_cmd() + [
-        "-f",
-        str(compose_path),
-        "-p",
-        project_name,
-    ]
+def _compose_cmd(
+    compose_path: Path, project_name: Optional[str] = None
+) -> list[str]:
+    cmd = _docker_compose_base_cmd() + ["-f", str(compose_path)]
+    if project_name:
+        cmd.extend(["-p", project_name])
+    return cmd
 
 
 def _notify(message: str) -> None:
     """Print a user-facing status line (compose starts before SIC logging is up)."""
     print(message, file=sys.stderr, flush=True)
+
+
+def _image_exists(image_ref: str) -> bool:
+    ref = image_ref if ":" in image_ref else image_ref + ":latest"
+    return (
+        subprocess.run(
+            ["docker", "image", "inspect", ref],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def _rebuild_requested() -> bool:
+    return os.environ.get("SIC_COMPOSE_REBUILD", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
+def _service_image_names(project_name: str) -> list[str]:
+    return ["{}-{}".format(project_name, svc) for svc in ("gpt", "datastore")]
+
+
+def _ensure_images(
+    base: list[str],
+    env: dict[str, str],
+    project_name: str,
+) -> bool:
+    """
+    Build images that are not present locally (or all images when rebuild requested).
+
+    Returns True if any build step ran.
+    """
+    built = False
+    rebuild = _rebuild_requested()
+
+    if rebuild or not _image_exists("sic-base:local"):
+        _notify("Building shared sic-base image...")
+        _run_compose(
+            base + ["--profile", "build", "build", "sic-base"],
+            env,
+            "build (sic-base)",
+        )
+        built = True
+
+    missing_services = [
+        img
+        for img in _service_image_names(project_name)
+        if rebuild or not _image_exists(img)
+    ]
+    if missing_services:
+        _notify("Building service images ({})...".format(", ".join(missing_services)))
+        _run_compose(base + ["build", "gpt", "datastore"], env, "build")
+        built = True
+
+    return built
 
 
 def _run_compose(cmd: list[str], env: dict[str, str], action: str) -> None:
@@ -111,8 +187,8 @@ def _run_compose(cmd: list[str], env: dict[str, str], action: str) -> None:
 
 def start(
     compose_path: Path,
-    project_name: str,
     host_ip: str,
+    project_name: Optional[str] = None,
     *,
     redis_host: str = "127.0.0.1",
     redis_port: int = 6379,
@@ -120,37 +196,37 @@ def start(
 ) -> None:
     """
     Build and start the compose stack, then wait until Redis is reachable on the host.
+
+    The compose project name comes from the top-level ``name:`` field in the compose
+    file unless ``project_name`` is passed to override it.
     """
     env = os.environ.copy()
     env["SIC_HOST_IP"] = host_ip
 
+    display_name = compose_project_name(compose_path, project_name)
     base = _compose_cmd(compose_path, project_name)
 
     _notify(
         "Starting background services from {} (project: {})...".format(
-            compose_path.name, project_name
+            compose_path.name, display_name
         )
     )
-    _notify(
-        "Hold tight — the first run builds Docker images and can take a few minutes."
-    )
 
-    _notify("Building shared sic-base image...")
-    # Build shared sic-base image before service images that FROM sic-base:local.
-    _run_compose(
-        base + ["--profile", "build", "build", "sic-base"],
-        env,
-        "build (sic-base)",
-    )
+    built = _ensure_images(base, env, display_name)
+    if built:
+        _notify(
+            "Hold tight — building Docker images can take a few minutes on first run."
+        )
+    else:
+        _notify("Using existing Docker images, starting containers...")
 
-    _notify("Building and starting service containers...")
-    _run_compose(base + ["up", "-d", "--build", "--wait"], env, "up")
+    _run_compose(base + ["up", "-d", "--wait"], env, "up")
 
     _wait_for_tcp(redis_host, redis_port, timeout_sec=startup_timeout_sec)
     _notify("Background services are ready.")
 
 
-def stop(compose_path: Path, project_name: str) -> None:
+def stop(compose_path: Path, project_name: Optional[str] = None) -> None:
     """Stop and remove containers for the compose project."""
     if shutil.which("docker") is None:
         return

--- a/sic_framework/core/utils.py
+++ b/sic_framework/core/utils.py
@@ -26,6 +26,10 @@ def get_ip_adress():
     :return: The IP address of the device.
     :rtype: str
     """
+    sic_ip = os.environ.get("SIC_IP") or os.environ.get("SIC_HOST_IP")
+    if sic_ip:
+        return sic_ip
+
     use_tailscale = os.environ.get("USE_TAILSCALE", "").lower() in ("1", "true", "yes")
 
     if use_tailscale:

--- a/sic_framework/devices/common_mini/mini_camera.py
+++ b/sic_framework/devices/common_mini/mini_camera.py
@@ -23,19 +23,19 @@ class MiniCameraConf(SICConfMessage):
 
     - It opens a TCP server socket on the Alphamini (or host running SIC).
     - An external Android camera app connects as a client and streams frames.
-    - Each frame is sent as: 4‑byte big‑endian length header + JPEG‑encoded image bytes.
+    - Each frame is sent as: 4-byte big-endian length header + JPEG-encoded image bytes.
 
     The Android app is responsible for:
     - Capturing frames from the Alphamini camera.
-    - JPEG‑encoding each frame to a byte array.
-    - Sending ``len(frame_bytes)`` as a 4‑byte big‑endian integer, followed by the bytes.
+    - JPEG-encoding each frame to a byte array.
+    - Sending ``len(frame_bytes)`` as a 4-byte big-endian integer, followed by the bytes.
 
     Additionally, this configuration can control basic camera streaming parameters
     on the Android side by passing intent extras when the app is started:
 
     - target_width / target_height: desired preview resolution (if supported).
     - scale: fractional scale of the default preview size.
-    - jpeg_quality: JPEG quality (0–100).
+    - jpeg_quality: JPEG quality (0-100).
     """
 
     def __init__(
@@ -57,13 +57,13 @@ class MiniCameraConf(SICConfMessage):
             Desired preview width in pixels. Default 0 lets the Android Camera API
             pick its preferred preview size (typically 640x480 on Alphamini).
         :param target_height:
-            Desired preview height in pixels. Default 0 uses the camera’s preferred
+            Desired preview height in pixels. Default 0 uses the camera's preferred
             preview height.
         :param scale:
             Fractional scaling factor applied on top of the desired size chosen by
             the Android side. Concretely, the Android ``CameraActivity``:
 
-            - starts from the camera’s preferred preview size,
+            - starts from the camera's preferred preview size,
             - optionally overrides that with ``target_width``/``target_height`` if
               both are > 0,
             - and then multiplies the resulting width/height by ``scale`` before
@@ -72,9 +72,9 @@ class MiniCameraConf(SICConfMessage):
             For example, if the preferred size is 640x480, ``scale=0.5`` yields an
             effective target of ~320x240. If you also set ``target_width`` and
             ``target_height``, they are used first and then scaled; they are *not*
-            ignored when a non‑default ``scale`` is provided.
+            ignored when a non-default ``scale`` is provided.
         :param jpeg_quality:
-            JPEG quality (0–100). Default 80, which is the quality used in the
+            JPEG quality (0-100). Default 80, which is the quality used in the
             original implementation before we started tuning for latency.
         :param send_fps:
             Optional maximum send rate from this sensor into SIC/Redis (in Hz).
@@ -95,12 +95,12 @@ class MiniCameraConf(SICConfMessage):
 
 class MiniCameraSensor(SICSensor):
     """
-    A SICSensor component that receives JPEG‑compressed image frames over TCP
+    A SICSensor component that receives JPEG-compressed image frames over TCP
     from an external Android camera application running on Alphamini.
 
     Protocol (one frame):
-        [4 bytes]  big‑endian unsigned int N  = length of JPEG payload
-        [N bytes]  JPEG‑encoded image bytes
+        [4 bytes]  big-endian unsigned int N  = length of JPEG payload
+        [N bytes]  JPEG-encoded image bytes
 
     For each complete frame, this sensor:
         - Decodes the JPEG bytes to a NumPy RGB array.
@@ -292,7 +292,7 @@ class MiniCameraSensor(SICSensor):
                 if not self.client_conn:
                     return None
 
-            # Read 8-byte capture timestamp (ms since epoch) and 4‑byte length header
+            # Read 8-byte capture timestamp (ms since epoch) and 4-byte length header
             ts_bytes = self._recv_exactly(8)
             if ts_bytes is None:
                 self.logger.warning("MiniCameraSensor: client disconnected before timestamp")
@@ -319,7 +319,7 @@ class MiniCameraSensor(SICSensor):
             (frame_len,) = struct.unpack("!I", header)
             if frame_len <= 0:
                 self.logger.warning(
-                    "MiniCameraSensor received non‑positive frame length: {length}".format(
+                    "MiniCameraSensor received non-positive frame length: {length}".format(
                         length=frame_len
                     )
                 )
@@ -348,7 +348,7 @@ class MiniCameraSensor(SICSensor):
                 self.logger.error("MiniCameraSensor JPEG decode error: {!r}".format(e))
                 return None
 
-            # Ensure we have a proper 3‑channel image
+            # Ensure we have a proper 3-channel image
             if not isinstance(image_np, np.ndarray) or image_np.ndim < 2:
                 self.logger.warning("MiniCameraSensor received invalid image array")
                 return None

--- a/sic_framework/devices/common_reachy_mini/reachy_mini_camera.py
+++ b/sic_framework/devices/common_reachy_mini/reachy_mini_camera.py
@@ -22,7 +22,7 @@ class ReachyMiniCameraSensor(SICSensor):
 
     Uses the singleton Reachy Mini SDK instance created by `ReachyMiniDevice`
     (stored on `ReachyMiniDevice._mini_instance`) to grab frames from
-    `mini.media.get_frame()`, then applies optional flipping and BGR→RGB
+    `mini.media.get_frame()`, then applies optional flipping and BGR->RGB
     conversion before emitting a `CompressedImageMessage`.
     """
 

--- a/sic_framework/docker/services/datastore/Dockerfile
+++ b/sic_framework/docker/services/datastore/Dockerfile
@@ -1,0 +1,5 @@
+FROM sic-base:local
+
+RUN pip install --no-cache-dir pypdf
+
+CMD ["run-redis", "--skip-docker"]

--- a/sic_framework/docker/services/datastore/Dockerfile
+++ b/sic_framework/docker/services/datastore/Dockerfile
@@ -1,5 +1,5 @@
 FROM sic-base:local
 
-RUN pip install --no-cache-dir pypdf
+RUN pip install --no-cache-dir pypdf "openai>=1.52.2"
 
 CMD ["run-redis", "--skip-docker"]

--- a/sic_framework/docker/services/dialogflow-cx/Dockerfile
+++ b/sic_framework/docker/services/dialogflow-cx/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[dialogflow-cx]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[dialogflow-cx]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-dialogflow-cx"]

--- a/sic_framework/docker/services/dialogflow/Dockerfile
+++ b/sic_framework/docker/services/dialogflow/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[dialogflow]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[dialogflow]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-dialogflow"]

--- a/sic_framework/docker/services/elevenlabs-tts/Dockerfile
+++ b/sic_framework/docker/services/elevenlabs-tts/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[elevenlabs-tts]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[elevenlabs-tts]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-elevenlabs-tts"]

--- a/sic_framework/docker/services/face-detection/Dockerfile
+++ b/sic_framework/docker/services/face-detection/Dockerfile
@@ -1,0 +1,5 @@
+FROM sic-base:local AS pypi
+CMD ["run-face-detection"]
+
+FROM sic-base:local AS local
+CMD ["run-face-detection"]

--- a/sic_framework/docker/services/google-stt/Dockerfile
+++ b/sic_framework/docker/services/google-stt/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[google-stt]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[google-stt]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-google-stt"]

--- a/sic_framework/docker/services/google-tts/Dockerfile
+++ b/sic_framework/docker/services/google-tts/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[google-tts]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[google-tts]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-google-tts"]

--- a/sic_framework/docker/services/gpt/Dockerfile
+++ b/sic_framework/docker/services/gpt/Dockerfile
@@ -1,0 +1,9 @@
+FROM sic-base:local AS pypi
+RUN pip install --no-cache-dir "openai>=1.52.2" "python-dotenv"
+CMD ["run-gpt"]
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[openai-gpt]" \
+    && rm -rf /tmp/social-interaction-cloud
+CMD ["run-gpt"]

--- a/sic_framework/docker/services/gpt/Dockerfile
+++ b/sic_framework/docker/services/gpt/Dockerfile
@@ -1,5 +1,6 @@
 FROM sic-base:local AS pypi
-RUN pip install --no-cache-dir "openai>=1.52.2" "python-dotenv"
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[openai-gpt]==${SIC_VERSION}"
 CMD ["run-gpt"]
 
 FROM sic-base:local AS local

--- a/sic_framework/docker/services/nao-mcp/Dockerfile
+++ b/sic_framework/docker/services/nao-mcp/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[mcp]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[mcp]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-nao-mcp"]

--- a/sic_framework/docker/services/nebula/Dockerfile
+++ b/sic_framework/docker/services/nebula/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[nebula]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[nebula]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-nebula"]

--- a/sic_framework/docker/services/object-detection/Dockerfile
+++ b/sic_framework/docker/services/object-detection/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[object-detection]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[object-detection]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-object-detection"]

--- a/sic_framework/docker/services/sortformer/Dockerfile
+++ b/sic_framework/docker/services/sortformer/Dockerfile
@@ -1,0 +1,12 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[sortformer]==${SIC_VERSION}" \
+    --extra-index-url https://download.pytorch.org/whl/cu130
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[sortformer]" \
+    --extra-index-url https://download.pytorch.org/whl/cu130 \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-sortformer"]

--- a/sic_framework/docker/services/voice-detection/Dockerfile
+++ b/sic_framework/docker/services/voice-detection/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[voice-detection]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[voice-detection]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-voice-detection"]

--- a/sic_framework/docker/services/webserver/Dockerfile
+++ b/sic_framework/docker/services/webserver/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[webserver]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[webserver]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-webserver"]

--- a/sic_framework/docker/services/whisper/Dockerfile
+++ b/sic_framework/docker/services/whisper/Dockerfile
@@ -1,0 +1,10 @@
+FROM sic-base:local AS pypi
+ARG SIC_VERSION
+RUN pip install --no-cache-dir "social-interaction-cloud[whisper-speech-to-text]==${SIC_VERSION}"
+
+FROM sic-base:local AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud[whisper-speech-to-text]" \
+    && rm -rf /tmp/social-interaction-cloud
+
+CMD ["run-whisper"]

--- a/sic_framework/docker/sic-base/Dockerfile
+++ b/sic_framework/docker/sic-base/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 
 # PyPI installs: build context is unused; sic_compose sets target=pypi.
 FROM base AS pypi
-ARG SIC_VERSION=2.2.3
+ARG SIC_VERSION
 RUN pip install --no-cache-dir "social-interaction-cloud==${SIC_VERSION}"
 
 # Source checkout: build context is the repo root; sic_compose sets target=local.

--- a/sic_framework/docker/sic-base/Dockerfile
+++ b/sic_framework/docker/sic-base/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim-bookworm AS base
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        procps \
+        gcc \
+        python3-dev \
+        portaudio19-dev \
+        libturbojpeg0 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# PyPI installs: build context is unused; sic_compose sets target=pypi.
+FROM base AS pypi
+ARG SIC_VERSION=2.2.3
+RUN pip install --no-cache-dir "social-interaction-cloud==${SIC_VERSION}"
+
+# Source checkout: build context is the repo root; sic_compose sets target=local.
+FROM base AS local
+COPY . /tmp/social-interaction-cloud
+RUN pip install --no-cache-dir "/tmp/social-interaction-cloud" \
+    && rm -rf /tmp/social-interaction-cloud

--- a/sic_framework/services/datastore/redis_datastore.py
+++ b/sic_framework/services/datastore/redis_datastore.py
@@ -27,7 +27,7 @@ All functionality is accessed via SIC service requests through RedisDatastoreCom
 
 === USAGE ===
 
-**Single command (Docker + datastore service)** — requires Docker installed:
+**Single command (Docker + datastore service)** - requires Docker installed:
 
     run-redis --data-dir /path/to/persist/redis-data
 
@@ -963,7 +963,7 @@ def _ingest_one_index(
     if not files:
         raise RuntimeError("No files matched under {} with glob {!r}".format(input_path, glob_pattern))
     
-    # Process each file: read → chunk → embed → store
+    # Process each file: read -> chunk -> embed -> store
     total_chunks = 0
     pipe = redis_conn.pipeline(transaction=False)
     for file_path in files:

--- a/sic_framework/services/datastore/redis_datastore.py
+++ b/sic_framework/services/datastore/redis_datastore.py
@@ -504,6 +504,19 @@ class StoreKeyspace:
 # SERVICE COMPONENT
 # ============================================================================
 
+def _service_redis_host(configured_host: str) -> str:
+    """
+    Resolve the Redis host for a service process.
+
+    Clients often pass ``127.0.0.1`` because Redis is published on localhost.
+    When the service runs inside Docker Compose, ``DB_IP`` points at the internal
+    ``redis`` service name instead.
+    """
+    if configured_host in ("127.0.0.1", "localhost", "::1"):
+        return os.getenv("DB_IP", configured_host)
+    return configured_host
+
+
 class RedisDatastoreComponent(SICService):
     """
     Redis Datastore Service Component
@@ -532,8 +545,9 @@ class RedisDatastoreComponent(SICService):
                 max_connections=self.params.max_connections,
             )
         else:
+            redis_host = _service_redis_host(self.params.host)
             pool = redis.ConnectionPool(
-                host=self.params.host,
+                host=redis_host,
                 port=self.params.port,
                 username=self.params.username,
                 password=self.params.password,
@@ -547,7 +561,7 @@ class RedisDatastoreComponent(SICService):
             
             # Binary connection pool for vector operations
             binary_pool = redis.ConnectionPool(
-                host=self.params.host,
+                host=redis_host,
                 port=self.params.port,
                 username=self.params.username,
                 password=self.params.password,

--- a/sic_framework/services/elevenlabs_tts/elevenlabs_tts.py
+++ b/sic_framework/services/elevenlabs_tts/elevenlabs_tts.py
@@ -43,8 +43,8 @@ class ElevenLabsTTSConf(SICConfMessage):
     :param voice_id: voice id
     :param model_id: model id (e.g., "eleven_flash_v2_5")
     :param sample_rate: used in output_format=pcm_<sample_rate>
-    :param speaking_rate: ElevenLabs "speed" (roughly 0.7–1.2)
-    :param stability: (0.0–1.0)
+    :param speaking_rate: ElevenLabs "speed" (roughly 0.7-1.2)
+    :param stability: (0.0-1.0)
     :param default_mode: "ws" or "batch"
     """
     def __init__(

--- a/sic_framework/services/webserver/webserver_service.py
+++ b/sic_framework/services/webserver/webserver_service.py
@@ -296,7 +296,7 @@ class WebserverComponent(SICService):
             allowed = getattr(self.params, "cors_allowed_origins", None)
             self.logger.error(
                 "Socket.IO CORS rejected origin '%s' (allowed=%r). "
-                "This usually shows up in the browser as 'Connecting…' forever. "
+                "This usually shows up in the browser as 'Connecting...' forever. "
                 "Fix by setting WebserverConf(cors_allowed_origins=[...]) to include the page origin (scheme+host+port).",
                 origin,
                 allowed,


### PR DESCRIPTION
Issue number: resolves #138

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

Demos and applications must start Redis and each SIC service manually (separate terminals or ad hoc `docker` commands). `SICApplication` only manages logging, Redis, connector/device cleanup, and shutdown signaling. Service Dockerfiles are not shipped in the PyPI package, and there is no standard way to bring up a demo-specific compose stack from application code.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds optional Docker Compose orchestration via `SICApplication(services_compose="docker-compose.yml")` (path resolved relative to the caller's source file).
- Introduces `sic_framework/core/sic_compose.py` to resolve compose paths, set `SIC_DOCKER_ROOT` / `SIC_BUILD_CONTEXT` / `SIC_BUILD_TARGET` / `SIC_VERSION` / `SIC_HOST_IP`, build missing images when needed, run `docker compose up -d --wait`, wait for Redis, monitor containers for errors, and run `docker compose down --remove-orphans` on shutdown.
- Ships `sic_framework/docker/` in the package (`sic-base` plus per-service Dockerfiles for datastore, dialogflow, dialogflow-cx, elevenlabs-tts, face-detection, google-stt, google-tts, gpt, nao-mcp, nebula, object-detection, sortformer, voice-detection, webserver, whisper).
- Reuses existing images when possible; prints user-facing messages while images build on first run.
- `utils.get_ip_adress()` honors `SIC_IP` / `SIC_HOST_IP` when set (used by compose services to reach the client host).
- Documents the workflow in `docs/source/architecture/docker.rst` and links it from the architecture index.
- Keeps robot runtimes working: non-ASCII characters removed from Python sources deployed to Python 2 devices; `sic_compose` is not imported on Python 2 (stub only) so NAO/NAOqi startup is unaffected.

**Usage (optional):**

```python
app = SICApplication(services_compose="docker-compose.yml")
```

Compose files can reference shipped Dockerfiles with `${SIC_DOCKER_ROOT}`, `${SIC_BUILD_CONTEXT}`, `${SIC_BUILD_TARGET}`, and `${SIC_VERSION}` as described in the new docs.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

