### PR TITLE
Add LocalVQE echo cancellation service

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,82 @@
-from setuptools import find_packages, setup
+from setuptools import Extension, find_packages, setup
+from setuptools.command.build_ext import build_ext as _build_ext
+import os
+import subprocess
 import sys
+
+try:
+    from setuptools.errors import CompileError, LibError, LinkError
+except ImportError:  # Python 2 / older setuptools
+    from distutils.errors import CompileError, LibError, LinkError
+
+
+class LocalVQEExtension(Extension):
+    """Marker extension: built by CMake in build_localvqe_ext, not distutils."""
+
+    def __init__(self):
+        Extension.__init__(
+            self, "sic_framework.services.localvqe._liblocalvqe", sources=[]
+        )
+
+
+class build_localvqe_ext(_build_ext):
+    """
+    Compile LocalVQE's liblocalvqe.so (CMake) during the build phase.
+
+    pip never tells setup.py which extras were requested, so this cannot be
+    gated on the [localvqe] extra: it runs on every source build and degrades
+    to a warning - never a failed SIC install - when the toolchain (git,
+    cmake >= 3.20, C++17 compiler) is missing or the compile fails. Repair or
+    rerun any time with `sic-build-localvqe`.
+    """
+
+    def run(self):
+        native = [e for e in self.extensions if isinstance(e, LocalVQEExtension)]
+        self.extensions = [
+            e for e in self.extensions if not isinstance(e, LocalVQEExtension)
+        ]
+        _build_ext.run(self)
+        if native:
+            self._build_localvqe()
+
+    def _build_localvqe(self):
+        if sys.version_info[0] < 3:
+            self._skip("requires Python 3 (robot installs never need it)")
+            return
+        import importlib.util
+
+        script = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "sic_framework", "services", "localvqe", "build_localvqe.py",
+        )
+        spec = importlib.util.spec_from_file_location("_sic_localvqe_build", script)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        try:
+            build_dir = module.build_for_setup()
+        except (CompileError, LinkError, LibError) as e:
+            self._skip("build failed: {}".format(e))
+            return
+        except (subprocess.CalledProcessError, OSError, RuntimeError) as e:
+            self._skip("build failed: {}".format(e))
+            return
+        if build_dir is None:
+            self._skip("required build tools missing (see messages above)")
+            return
+        if not self.inplace:
+            # build_py copies package data before build_ext runs; mirror the
+            # fresh libraries into the wheel's build tree as well.
+            dest = os.path.join(
+                self.build_lib, "sic_framework", "services", "localvqe", "lib"
+            )
+            module.copy_libs(build_dir, lib_dir=dest)
+
+    def _skip(self, reason):
+        print(
+            "[sic-localvqe] LocalVQE native library not built: {}; install "
+            "git/cmake >= 3.20/a C++17 compiler and reinstall, or run "
+            "sic-build-localvqe. The rest of SIC installs normally.".format(reason)
+        )
 
 # Basic (bare minimum) requirements for local machine
 requirements = [
@@ -96,6 +173,7 @@ else:
             "torch",
             "torchaudio",
             "numpy",
+            "packaging",
         ],
         "nebula": [
             "openai>=1.52.2",
@@ -114,6 +192,13 @@ else:
         "elevenlabs-tts": [
             "requests",
             "websockets==13.1",
+        ],
+        # LocalVQE (AEC + noise suppression + dereverb via GGML). Python-side
+        # deps only: pip cannot tell setup.py which extras were requested, so
+        # the native compile lives in build_ext (unconditional on source
+        # builds) rather than behind this extra.
+        "localvqe": [
+            "numpy",
         ],
         "mcp": [
             "langchain-mcp-adapters>=0.1.0",
@@ -143,6 +228,11 @@ setup(
         "lib.libturbojpeg.lib32": [
             "libturbojpeg.so.0",
         ],
+        # liblocalvqe.so + libggml*.so built by build_ext (build_localvqe_ext).
+        "sic_framework.services.localvqe": [
+            "lib/*.so*",
+            "lib/*.dylib",
+        ],
     },
     install_requires=requirements,
     extras_require=extras_require,
@@ -165,6 +255,12 @@ setup(
             "run-redis=sic_framework.services.datastore.redis_datastore:main",
             "run-sortformer=sic_framework.services.streaming_sortformer.stm_sortformer:main",
             "run-nao-mcp=sic_framework.mcp.nao.nao_mcp_server:main",
+            "run-localvqe=sic_framework.services.localvqe.localvqe_service:main",
+            "sic-build-localvqe=sic_framework.services.localvqe.build_localvqe:main",
         ],
+    },
+    ext_modules=[LocalVQEExtension()],
+    cmdclass={
+        "build_ext": build_localvqe_ext,
     },
 )

--- a/sic_framework/services/localvqe/__init__.py
+++ b/sic_framework/services/localvqe/__init__.py
@@ -1,0 +1,8 @@
+"""
+LocalVQE service package: SIC wrapper around LocalVQE's GGML streaming
+voice quality enhancement (AEC + noise suppression + dereverb).
+
+Kept import-light: the native binding is only loaded when the service (or
+sic_framework.services.localvqe.localvqe_binding) is actually used, so the
+sic-build-localvqe entry point works before liblocalvqe.so exists.
+"""

--- a/sic_framework/services/localvqe/build_localvqe.py
+++ b/sic_framework/services/localvqe/build_localvqe.py
@@ -1,0 +1,305 @@
+"""
+build_localvqe.py
+
+Fetch and build LocalVQE's liblocalvqe.so into this package's lib/ dir.
+Stdlib-only: loaded by file path from setup.py's build_ext on every source
+build, and installed as the `sic-build-localvqe` console script.
+"""
+
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
+
+DEFAULT_REPO_URL = "https://github.com/localai-org/LocalVQE.git"
+DEFAULT_SRC_DIR = os.path.join("~", ".cache", "sic", "localvqe-src")
+DEFAULT_MODEL_DIR = os.path.join("~", ".cache", "sic", "models")
+
+PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+PACKAGE_LIB_DIR = os.path.join(PACKAGE_DIR, "lib")
+
+# liblocalvqe.so dladdr-locates the libggml-cpu-*.so backend variants at
+# runtime, so all shipped libraries must stay co-located.
+LIB_PATTERNS = ("liblocalvqe.so*", "libggml*.so*", "liblocalvqe*.dylib", "libggml*.dylib")
+
+DEFAULT_MODEL_NAME = "localvqe-v1.3-4.8M-f32.gguf"
+
+# URLs and SHA-256 checksums as published in LocalVQE's ggml/CMakeLists.txt.
+HF_MODEL_BASE = "https://huggingface.co/LocalAI-io/LocalVQE/resolve/main/"
+KNOWN_MODELS = {
+    "localvqe-v1.3-4.8M-f32.gguf": "c4f7912485c32cfc206c536f2f050b52513f2f613fdbc616391f6b26ab1d51ec",
+    "localvqe-v1.2-1.3M-f32.gguf": "4856ecf5f522b23fb2bc5caeac81f323c0ef1c4c156a9c7d40a6adbe092ba9ce",
+    "localvqe-v1.4-aec-200K-f32.gguf": "b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731",
+}
+# Doubletalk mic/ref example clips (used by the parity self-test and demos).
+KNOWN_TESTDATA = {
+    "dt_mic.wav": (
+        "https://huggingface.co/spaces/LocalAI-io/LocalVQE-demo/resolve/main/examples/dt_mic.wav",
+        "8d0c15e56a4c7f387847451952123e8f23161520e81c1ba8878c922f11592a62",
+    ),
+    "dt_ref.wav": (
+        "https://huggingface.co/spaces/LocalAI-io/LocalVQE-demo/resolve/main/examples/dt_ref.wav",
+        "e931d49e2802c1d7b15750caff1455495cd1dc40d27cb2fe51a8c58cbebe60fe",
+    ),
+}
+
+
+
+def _run(cmd, cwd=None):
+    print("[sic-localvqe] $ " + " ".join(cmd) + ("" if cwd is None else "  (in {})".format(cwd)))
+    sys.stdout.flush()
+    subprocess.check_call(cmd, cwd=cwd)
+
+
+def _is_on_branch(src_dir):
+    return (
+        subprocess.call(
+            ["git", "symbolic-ref", "-q", "HEAD"],
+            cwd=src_dir,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        == 0
+    )
+
+
+def ensure_checkout(repo=None, ref=None, src_dir=None):
+    """Clone or fetch/pull LocalVQE (with its ggml submodule) into the cache dir."""
+    repo = repo or os.environ.get("LOCALVQE_REPO") or DEFAULT_REPO_URL
+    ref = ref or os.environ.get("LOCALVQE_REF") or None
+    src_dir = os.path.expanduser(src_dir or os.environ.get("LOCALVQE_SRC_DIR") or DEFAULT_SRC_DIR)
+
+    if os.path.isdir(os.path.join(src_dir, ".git")):
+        print("[sic-localvqe] reusing existing checkout: {}".format(src_dir))
+        _run(["git", "remote", "set-url", "origin", repo], cwd=src_dir)
+        _run(["git", "fetch", "--tags", "origin"], cwd=src_dir)
+        if ref:
+            _run(["git", "checkout", ref], cwd=src_dir)
+        if _is_on_branch(src_dir):
+            pull = ["git", "pull", "--ff-only", "origin"]
+            if ref:
+                pull.append(ref)
+            _run(pull, cwd=src_dir)
+    else:
+        parent = os.path.dirname(src_dir)
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent)
+        # LocalVQE vendors ggml as a git submodule, hence --recursive.
+        _run(["git", "clone", "--recursive", repo, src_dir])
+        if ref:
+            _run(["git", "checkout", ref], cwd=src_dir)
+
+    # --force: cmake patches the vendored ggml tree at configure time, so the
+    # submodule is legitimately dirty; reset it and let cmake re-apply.
+    _run(["git", "submodule", "update", "--init", "--recursive", "--force"], cwd=src_dir)
+    return src_dir
+
+
+def build_native(src_dir, jobs=None, extra_cmake_args=None):
+    """Configure and build the shared library; returns the build directory."""
+    ggml_dir = os.path.join(src_dir, "ggml")
+    build_dir = os.path.join(ggml_dir, "build")
+
+    configure = [
+        "cmake",
+        "-S", ggml_dir,
+        "-B", build_dir,
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DLOCALVQE_BUILD_SHARED=ON",
+    ]
+    # optional non-system libsndfile so the WAV CLI tools build without root
+    sndfile_lib = os.environ.get("SNDFILE_LIBRARY")
+    sndfile_inc = os.environ.get("SNDFILE_INCLUDE_DIR")
+    if sndfile_lib and sndfile_inc:
+        configure.append("-DSNDFILE_LIBRARY={}".format(sndfile_lib))
+        configure.append("-DSNDFILE_INCLUDE_DIR={}".format(sndfile_inc))
+    env_args = os.environ.get("LOCALVQE_CMAKE_ARGS", "").split()
+    configure.extend(env_args)
+    if extra_cmake_args:
+        configure.extend(extra_cmake_args)
+
+    _run(configure)
+    _run(["cmake", "--build", build_dir, "-j", str(jobs or os.cpu_count() or 2)])
+    return build_dir
+
+
+def copy_libs(build_dir, lib_dir=None):
+    """Copy liblocalvqe.so + libggml*.so into the package lib/ dir, keeping symlinks."""
+    import glob
+
+    bin_dir = os.path.join(build_dir, "bin")
+    lib_dir = lib_dir or PACKAGE_LIB_DIR
+    if not os.path.isdir(lib_dir):
+        os.makedirs(lib_dir)
+
+    sources = []
+    for pattern in LIB_PATTERNS:
+        sources.extend(glob.glob(os.path.join(bin_dir, pattern)))
+    sources = sorted(set(sources))
+
+    if not any(os.path.basename(s).startswith("liblocalvqe.so") for s in sources):
+        raise RuntimeError(
+            "liblocalvqe.so not found in {} - the build did not produce the "
+            "shared library (was -DLOCALVQE_BUILD_SHARED=ON used?)".format(bin_dir)
+        )
+
+    # Drop stale copies first so removed CPU variants don't linger.
+    for pattern in LIB_PATTERNS:
+        for stale in glob.glob(os.path.join(lib_dir, pattern)):
+            os.remove(stale)
+
+    installed = []
+    for src in sources:
+        name = os.path.basename(src)
+        dst = os.path.join(lib_dir, name)
+        if os.path.islink(src):
+            os.symlink(os.readlink(src), dst)
+        else:
+            shutil.copy2(src, dst)
+        installed.append(name)
+
+    print("[sic-localvqe] installed into {}:".format(lib_dir))
+    for name in installed:
+        print("[sic-localvqe]   {}".format(name))
+    return installed
+
+
+def missing_build_tools():
+    """Return a list of (tool, hint) tuples for required tools that are absent."""
+    missing = []
+    if not shutil.which("git"):
+        missing.append(("git", "needed to clone https://github.com/localai-org/LocalVQE.git"))
+    if not shutil.which("cmake"):
+        missing.append(("cmake", "cmake >= 3.20 is required"))
+    if not (shutil.which("g++") or shutil.which("clang++") or shutil.which("c++")):
+        missing.append(("C++ compiler", "a C++17 compiler (g++ or clang++) is required"))
+    return missing
+
+
+def libsndfile_available():
+    """Best-effort check for libsndfile development files (optional, CLI-only)."""
+    if os.environ.get("SNDFILE_LIBRARY") and os.environ.get("SNDFILE_INCLUDE_DIR"):
+        return True
+    candidates = ["/usr/include", "/usr/local/include", "/opt/homebrew/include"]
+    return any(os.path.isfile(os.path.join(d, "sndfile.h")) for d in candidates)
+
+
+def build_all(repo=None, ref=None, src_dir=None, lib_dir=None, jobs=None, extra_cmake_args=None):
+    """Clone/update, compile, and install the shared libraries. Returns installed names."""
+    src = ensure_checkout(repo=repo, ref=ref, src_dir=src_dir)
+    build_dir = build_native(src, jobs=jobs, extra_cmake_args=extra_cmake_args)
+    return copy_libs(build_dir, lib_dir=lib_dir)
+
+
+def _sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _download(url, dest, sha256=None):
+    if os.path.isfile(dest) and sha256 and _sha256(dest) == sha256:
+        print("[sic-localvqe] {} already present (checksum OK)".format(dest))
+        return dest
+    print("[sic-localvqe] downloading {} -> {}".format(url, dest))
+    tmp = dest + ".part"
+    urllib.request.urlretrieve(url, tmp)
+    if sha256:
+        got = _sha256(tmp)
+        if got != sha256:
+            os.remove(tmp)
+            raise RuntimeError("checksum mismatch for {}: got {}, expected {}".format(url, got, sha256))
+    os.replace(tmp, dest)
+    return dest
+
+
+def download_model(name=DEFAULT_MODEL_NAME, model_dir=None):
+    """Download a LocalVQE GGUF from HuggingFace into the model cache dir."""
+    model_dir = os.path.expanduser(model_dir or os.environ.get("LOCALVQE_MODEL_DIR") or DEFAULT_MODEL_DIR)
+    if not os.path.isdir(model_dir):
+        os.makedirs(model_dir)
+    sha = KNOWN_MODELS.get(name)
+    if sha is None:
+        print("[sic-localvqe] warning: no known checksum for {}; skipping verification".format(name))
+    return _download(HF_MODEL_BASE + name, os.path.join(model_dir, name), sha256=sha)
+
+
+def download_testdata(model_dir=None):
+    """Download the doubletalk mic/ref example WAV pair next to the models."""
+    model_dir = os.path.expanduser(model_dir or os.environ.get("LOCALVQE_MODEL_DIR") or DEFAULT_MODEL_DIR)
+    if not os.path.isdir(model_dir):
+        os.makedirs(model_dir)
+    paths = []
+    for name, (url, sha) in sorted(KNOWN_TESTDATA.items()):
+        paths.append(_download(url, os.path.join(model_dir, name), sha256=sha))
+    return paths
+
+
+def build_for_setup():
+    """
+    setup.py build_ext hook: build unconditionally; returns the CMake build
+    dir, or None (with printed specifics) when required tools are missing.
+    """
+    missing = missing_build_tools()
+    if missing:
+        print("[sic-localvqe] cannot build the LocalVQE native library:")
+        for tool, hint in missing:
+            print("[sic-localvqe]   - {}: {}".format(tool, hint))
+        return None
+    if not libsndfile_available():
+        print("[sic-localvqe] note: libsndfile not found - optional, only for the WAV CLI tools.")
+    src = ensure_checkout()
+    build_dir = build_native(src)
+    copy_libs(build_dir)
+    return build_dir
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="sic-build-localvqe",
+        description="Clone and build LocalVQE's liblocalvqe.so for the SIC LocalVQE service "
+                    "(same steps as the install-time build_ext hook).",
+    )
+    parser.add_argument("--repo", default=None, help="git URL (default: $LOCALVQE_REPO or upstream)")
+    parser.add_argument("--ref", default=None, help="branch/tag/commit (default: $LOCALVQE_REF or repo default)")
+    parser.add_argument("--src-dir", default=None, help="checkout cache dir (default: $LOCALVQE_SRC_DIR or ~/.cache/sic/localvqe-src)")
+    parser.add_argument("--lib-dir", default=None, help="destination for the built .so files (default: the packaged lib/ dir)")
+    parser.add_argument("--jobs", "-j", type=int, default=None, help="parallel build jobs (default: nproc)")
+    parser.add_argument("--cmake-arg", action="append", default=[], metavar="ARG",
+                        help="extra cmake configure argument (repeatable)")
+    parser.add_argument("--skip-build", action="store_true", help="skip clone+build (e.g. only download assets)")
+    parser.add_argument("--download-model", nargs="?", const=DEFAULT_MODEL_NAME, default=None, metavar="GGUF",
+                        help="also download a GGUF model (default: {})".format(DEFAULT_MODEL_NAME))
+    parser.add_argument("--download-testdata", action="store_true",
+                        help="also download the doubletalk mic/ref example WAV pair")
+    parser.add_argument("--model-dir", default=None,
+                        help="where to store models/testdata (default: $LOCALVQE_MODEL_DIR or ~/.cache/sic/models)")
+    args = parser.parse_args(argv)
+
+    if not args.skip_build:
+        missing = missing_build_tools()
+        if missing:
+            for tool, hint in missing:
+                print("[sic-localvqe] missing {}: {}".format(tool, hint))
+            return 1
+        if not libsndfile_available():
+            print("[sic-localvqe] note: libsndfile headers not found; WAV CLI tools will be skipped "
+                  "(liblocalvqe.so itself does not need libsndfile).")
+        build_all(repo=args.repo, ref=args.ref, src_dir=args.src_dir,
+                  lib_dir=args.lib_dir, jobs=args.jobs, extra_cmake_args=args.cmake_arg)
+
+    if args.download_model:
+        print("[sic-localvqe] model: {}".format(download_model(args.download_model, model_dir=args.model_dir)))
+    if args.download_testdata:
+        for p in download_testdata(model_dir=args.model_dir):
+            print("[sic-localvqe] testdata: {}".format(p))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sic_framework/services/localvqe/lib/.gitignore
+++ b/sic_framework/services/localvqe/lib/.gitignore
@@ -1,0 +1,5 @@
+# Native build artifacts installed by the setup.py build_ext hook / sic-build-localvqe.
+*.so
+*.so.*
+*.dylib
+!.gitignore

--- a/sic_framework/services/localvqe/localvqe_binding.py
+++ b/sic_framework/services/localvqe/localvqe_binding.py
@@ -1,0 +1,511 @@
+"""
+localvqe_binding.py
+
+Pure-ctypes binding for LocalVQE's GGML C API (liblocalvqe.so), modeled on
+ggml/example_purego_test.go: dlopen + per-symbol argtypes, no compiled glue.
+Signatures follow ggml/localvqe_api.h; audio is 16 kHz mono float32 in [-1, 1].
+"""
+
+import ctypes
+import os
+from ctypes import POINTER, c_char_p, c_float, c_int, c_int16, c_size_t
+
+import numpy as np
+
+PACKAGED_LIB_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib")
+
+DEFAULT_MODEL_NAME = "localvqe-v1.3-4.8M-f32.gguf"
+DEFAULT_MODEL_DIR = os.path.join("~", ".cache", "sic", "models")
+
+
+class LocalVQEError(RuntimeError):
+    """Raised when the native LocalVQE library reports an error."""
+
+
+def default_lib_path():
+    """Resolve liblocalvqe.so: $LOCALVQE_LIBRARY wins, then the packaged lib/ dir."""
+    env = os.environ.get("LOCALVQE_LIBRARY")
+    if env:
+        return os.path.expanduser(env)
+    return os.path.join(PACKAGED_LIB_DIR, "liblocalvqe.so")
+
+
+def default_model_path():
+    """$LOCALVQE_MODEL (a file path) wins, then ~/.cache/sic/models/<default gguf>."""
+    env = os.environ.get("LOCALVQE_MODEL")
+    if env:
+        return os.path.expanduser(env)
+    return os.path.join(os.path.expanduser(DEFAULT_MODEL_DIR), DEFAULT_MODEL_NAME)
+
+
+# -- library loading and symbol registration (purego.RegisterLibFunc analog) --
+
+# localvqe_ctx_t / localvqe_options_t are uintptr_t, i.e. pointer-sized ints.
+_ctx_t = c_size_t
+_opts_t = c_size_t
+
+_SIGNATURES = {
+    # name: (argtypes, restype)
+    "localvqe_new": ([c_char_p], _ctx_t),
+    "localvqe_new_with_frontend": ([c_char_p, c_char_p], _ctx_t),
+    "localvqe_options_new": ([], _opts_t),
+    "localvqe_options_free": ([_opts_t], None),
+    "localvqe_options_set_model_path": ([_opts_t, c_char_p], c_int),
+    "localvqe_options_set_backend": ([_opts_t, c_char_p], c_int),
+    "localvqe_options_set_device": ([_opts_t, c_int], c_int),
+    "localvqe_options_set_frontend_path": ([_opts_t, c_char_p], c_int),
+    "localvqe_options_set_threads": ([_opts_t, c_int], c_int),
+    "localvqe_new_with_options": ([_opts_t], _ctx_t),
+    "localvqe_list_devices": ([], None),
+    "localvqe_print_profile": ([_ctx_t], None),
+    "localvqe_free": ([_ctx_t], None),
+    "localvqe_process_f32": ([_ctx_t, POINTER(c_float), POINTER(c_float), c_int, POINTER(c_float)], c_int),
+    "localvqe_process_s16": ([_ctx_t, POINTER(c_int16), POINTER(c_int16), c_int, POINTER(c_int16)], c_int),
+    "localvqe_last_error": ([_ctx_t], c_char_p),
+    "localvqe_sample_rate": ([_ctx_t], c_int),
+    "localvqe_hop_length": ([_ctx_t], c_int),
+    "localvqe_fft_size": ([_ctx_t], c_int),
+    "localvqe_process_frame_f32": ([_ctx_t, POINTER(c_float), POINTER(c_float), c_int, POINTER(c_float)], c_int),
+    "localvqe_process_frame_s16": ([_ctx_t, POINTER(c_int16), POINTER(c_int16), c_int, POINTER(c_int16)], c_int),
+    "localvqe_reset": ([_ctx_t], None),
+    "localvqe_set_noise_gate": ([_ctx_t, c_int, c_float], c_int),
+    "localvqe_get_noise_gate": ([_ctx_t, POINTER(c_int), POINTER(c_float)], c_int),
+}
+
+_lib_cache = {}
+
+
+def load_liblocalvqe(lib_path=None):
+    """dlopen liblocalvqe.so and register argtypes/restype for every symbol."""
+    path = os.path.abspath(lib_path or default_lib_path())
+    if path in _lib_cache:
+        return _lib_cache[path]
+
+    if not os.path.isfile(path):
+        raise LocalVQEError(
+            f"liblocalvqe.so not found at {path}. The native build was skipped "
+            f"during install (missing git/cmake/C++17 toolchain?); install the "
+            f"tools and run: sic-build-localvqe\n"
+            f"(override the location with $LOCALVQE_LIBRARY or the lib_path argument)"
+        )
+
+    # Mirrors purego.Dlopen(path, RTLD_LAZY); the library dladdr-locates its
+    # co-located libggml-cpu-*.so backends itself.
+    lib = ctypes.CDLL(path, mode=os.RTLD_LAZY | os.RTLD_LOCAL)
+
+    for name, (argtypes, restype) in _SIGNATURES.items():
+        try:
+            fn = getattr(lib, name)
+        except AttributeError:
+            raise LocalVQEError(f"symbol {name} missing from {path} - library too old?")
+        fn.argtypes = argtypes
+        fn.restype = restype
+
+    _lib_cache[path] = lib
+    return lib
+
+
+# -- int16 PCM <-> float32 helpers --
+
+def pcm16_to_f32(data):
+    """Convert int16 PCM (LE bytes or int16 ndarray) to float32 in [-1, 1]."""
+    if isinstance(data, (bytes, bytearray, memoryview)):
+        arr = np.frombuffer(data, dtype="<i2")
+    else:
+        arr = np.asarray(data, dtype=np.int16)
+    return arr.astype(np.float32) / 32768.0
+
+
+def f32_to_pcm16(samples):
+    """Convert float32 samples in [-1, 1] to int16 PCM little-endian bytes."""
+    arr = np.asarray(samples, dtype=np.float32)
+    clipped = np.clip(arr, -1.0, 1.0)
+    return (np.round(clipped * 32767.0)).astype("<i2").tobytes()
+
+
+def _as_f32_buffer(x, name, length=None):
+    """Validate/convert to a 1-D contiguous float32 array."""
+    arr = np.ascontiguousarray(x, dtype=np.float32)
+    if arr.ndim != 1:
+        raise ValueError(f"{name} must be a 1-D array of mono samples, got shape {arr.shape}")
+    if length is not None and arr.shape[0] != length:
+        raise ValueError(f"{name} must have {length} samples, got {arr.shape[0]}")
+    return arr
+
+
+def _f32_ptr(arr):
+    return arr.ctypes.data_as(POINTER(c_float))
+
+
+# -- high-level wrapper (analog of the Go LocalVQE struct) --
+
+class LocalVQE:
+    """
+    A LocalVQE inference context: AEC + noise suppression + dereverb on
+    16 kHz mono audio.
+
+    :param model_path: LocalVQE .gguf; None = $LOCALVQE_MODEL or the cache dir.
+    :param threads: ggml CPU threads, None/0 = auto.
+    :param backend: ggml backend name ("CPU", "Vulkan", ...), None = CPU.
+    :param device: device index within the backend, None = 0.
+    :param frontend_path: separate v1.4-AEC front-end gguf (GTCRN line only).
+    :param noise_gate_dbfs: residual-echo gate threshold in dBFS, None = off.
+    :param lib_path: liblocalvqe.so path; None = packaged lib dir.
+    """
+
+    def __init__(self, model_path=None, threads=None, backend=None, device=None,
+                 frontend_path=None, noise_gate_dbfs=None, lib_path=None):
+        self._ctx = 0
+        self._lib = load_liblocalvqe(lib_path)
+
+        model_path = os.path.expanduser(model_path or default_model_path())
+        if not os.path.isfile(model_path):
+            default_cache = os.path.join(
+                os.path.expanduser(DEFAULT_MODEL_DIR), DEFAULT_MODEL_NAME
+            )
+            if model_path == default_cache:
+                # First-start fetch of the default model. Deliberately not done
+                # at build time: pip caches/moves wheels across machines, while
+                # the model cache is per-machine.
+                from sic_framework.services.localvqe import build_localvqe
+
+                try:
+                    build_localvqe.download_model()
+                except Exception as e:
+                    raise LocalVQEError(
+                        f"could not download the default LocalVQE model to "
+                        f"{model_path}: {e}\n"
+                        f"retry, or run: sic-build-localvqe --skip-build --download-model"
+                    )
+            else:
+                raise LocalVQEError(
+                    f"LocalVQE model not found: {model_path}\n"
+                    f"(point $LOCALVQE_MODEL / the model_path argument at a .gguf, "
+                    f"or run: sic-build-localvqe --skip-build --download-model)"
+                )
+
+        if threads or backend or device is not None or frontend_path:
+            opts = self._lib.localvqe_options_new()
+            if not opts:
+                raise LocalVQEError("localvqe_options_new failed")
+            try:
+                self._check_opt(opts, "model_path",
+                                self._lib.localvqe_options_set_model_path(opts, model_path.encode("utf-8")))
+                if threads:
+                    self._check_opt(opts, "threads",
+                                    self._lib.localvqe_options_set_threads(opts, int(threads)))
+                if backend:
+                    self._check_opt(opts, "backend",
+                                    self._lib.localvqe_options_set_backend(opts, backend.encode("utf-8")))
+                if device is not None:
+                    self._check_opt(opts, "device",
+                                    self._lib.localvqe_options_set_device(opts, int(device)))
+                if frontend_path:
+                    fe = os.path.expanduser(frontend_path)
+                    self._check_opt(opts, "frontend_path",
+                                    self._lib.localvqe_options_set_frontend_path(opts, fe.encode("utf-8")))
+                self._ctx = self._lib.localvqe_new_with_options(opts)
+            finally:
+                self._lib.localvqe_options_free(opts)
+        else:
+            self._ctx = self._lib.localvqe_new(model_path.encode("utf-8"))
+
+        if not self._ctx:
+            raise LocalVQEError(
+                f"localvqe_new failed for {model_path} "
+                f"(backend={backend or 'CPU'}, device={device or 0})"
+            )
+
+        self.model_path = model_path
+        self._sample_rate = int(self._lib.localvqe_sample_rate(self._ctx))
+        self._hop_length = int(self._lib.localvqe_hop_length(self._ctx))
+        self._fft_size = int(self._lib.localvqe_fft_size(self._ctx))
+
+        if noise_gate_dbfs is not None:
+            self.set_noise_gate(True, noise_gate_dbfs)
+
+    @staticmethod
+    def _check_opt(opts, what, rc):
+        if rc != 0:
+            raise LocalVQEError(f"localvqe_options_set_{what} failed (rc={rc})")
+
+    # -- properties ---------------------------------------------------------
+
+    @property
+    def sample_rate(self):
+        """Model sample rate in Hz (16000)."""
+        return self._sample_rate
+
+    @property
+    def hop_length(self):
+        """Streaming hop size in samples (256)."""
+        return self._hop_length
+
+    @property
+    def fft_size(self):
+        """Analysis FFT size in samples (512) - the minimum whole-clip length."""
+        return self._fft_size
+
+    # -- core API -----------------------------------------------------------
+
+    def last_error(self):
+        """Last error message from the native context, or ''."""
+        if not self._ctx:
+            return ""
+        raw = self._lib.localvqe_last_error(self._ctx)
+        return raw.decode("utf-8", "replace") if raw else ""
+
+    def process(self, mic, ref=None, n_samples=None):
+        """
+        Whole-clip enhancement (localvqe_process_f32): 1-D float32 in [-1, 1],
+        n_samples >= fft_size; ref None = zeros (NS + dereverb only).
+        Returns enhanced float32, sample-aligned to the input.
+        """
+        self._ensure_open()
+        mic = _as_f32_buffer(mic, "mic")
+        if ref is None:
+            ref = np.zeros_like(mic)
+        else:
+            ref = _as_f32_buffer(ref, "ref", length=mic.shape[0])
+        if n_samples is None:
+            n_samples = mic.shape[0]
+        if n_samples > mic.shape[0]:
+            raise ValueError(f"n_samples={n_samples} exceeds buffer length {mic.shape[0]}")
+        if n_samples < self._fft_size:
+            raise ValueError(
+                f"localvqe_process_f32 needs n_samples >= {self._fft_size}, got {n_samples} "
+                f"(use process_frame() for streaming hops)"
+            )
+
+        out = np.empty(n_samples, dtype=np.float32)
+        rc = self._lib.localvqe_process_f32(
+            self._ctx, _f32_ptr(mic), _f32_ptr(ref), int(n_samples), _f32_ptr(out)
+        )
+        if rc != 0:
+            raise LocalVQEError(f"localvqe_process_f32 error {rc}: {self.last_error()}")
+        return out
+
+    def process_s16(self, mic, ref=None):
+        """Whole-clip enhancement on int16 PCM (localvqe_process_s16)."""
+        self._ensure_open()
+        if isinstance(mic, (bytes, bytearray, memoryview)):
+            mic = np.frombuffer(mic, dtype="<i2")
+        mic = np.ascontiguousarray(mic, dtype=np.int16)
+        if ref is None:
+            ref = np.zeros_like(mic)
+        else:
+            if isinstance(ref, (bytes, bytearray, memoryview)):
+                ref = np.frombuffer(ref, dtype="<i2")
+            ref = np.ascontiguousarray(ref, dtype=np.int16)
+            if ref.shape != mic.shape:
+                raise ValueError("mic and ref must have the same length")
+        n = mic.shape[0]
+        if n < self._fft_size:
+            raise ValueError(f"localvqe_process_s16 needs n_samples >= {self._fft_size}, got {n}")
+        out = np.empty(n, dtype=np.int16)
+        rc = self._lib.localvqe_process_s16(
+            self._ctx,
+            mic.ctypes.data_as(POINTER(c_int16)),
+            ref.ctypes.data_as(POINTER(c_int16)),
+            int(n),
+            out.ctypes.data_as(POINTER(c_int16)),
+        )
+        if rc != 0:
+            raise LocalVQEError(f"localvqe_process_s16 error {rc}: {self.last_error()}")
+        return out
+
+    def process_frame(self, mic, ref=None):
+        """Streaming enhancement of one hop (256 float32 samples); ref None = zeros."""
+        self._ensure_open()
+        mic = _as_f32_buffer(mic, "mic", length=self._hop_length)
+        if ref is None:
+            ref = np.zeros_like(mic)
+        else:
+            ref = _as_f32_buffer(ref, "ref", length=self._hop_length)
+        out = np.empty(self._hop_length, dtype=np.float32)
+        rc = self._lib.localvqe_process_frame_f32(
+            self._ctx, _f32_ptr(mic), _f32_ptr(ref), self._hop_length, _f32_ptr(out)
+        )
+        if rc != 0:
+            raise LocalVQEError(f"localvqe_process_frame_f32 error {rc}: {self.last_error()}")
+        return out
+
+    def reset(self):
+        """Reset streaming state to initial zeros (between utterances/streams)."""
+        self._ensure_open()
+        self._lib.localvqe_reset(self._ctx)
+
+    def set_noise_gate(self, enabled, threshold_dbfs=-45.0):
+        """Enable/disable the residual-echo noise gate (localvqe_set_noise_gate)."""
+        self._ensure_open()
+        rc = self._lib.localvqe_set_noise_gate(self._ctx, 1 if enabled else 0, float(threshold_dbfs))
+        if rc != 0:
+            raise LocalVQEError(f"localvqe_set_noise_gate error {rc}: {self.last_error()}")
+
+    def get_noise_gate(self):
+        """Return (enabled, threshold_dbfs) of the residual-echo noise gate."""
+        self._ensure_open()
+        enabled = c_int(0)
+        threshold = c_float(0.0)
+        rc = self._lib.localvqe_get_noise_gate(self._ctx, ctypes.byref(enabled), ctypes.byref(threshold))
+        if rc != 0:
+            raise LocalVQEError(f"localvqe_get_noise_gate error {rc}: {self.last_error()}")
+        return bool(enabled.value), float(threshold.value)
+
+    def print_profile(self):
+        """Print memory budget + graph op histogram to stdout (diagnostic)."""
+        self._ensure_open()
+        self._lib.localvqe_print_profile(self._ctx)
+
+    def close(self):
+        """Free the native context (localvqe_free). Safe to call twice."""
+        if self._ctx:
+            self._lib.localvqe_free(self._ctx)
+            self._ctx = 0
+
+    def _ensure_open(self):
+        if not self._ctx:
+            raise LocalVQEError("LocalVQE context is closed")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+def list_devices(lib_path=None):
+    """Print every registered ggml backend + device to stderr (no model needed)."""
+    load_liblocalvqe(lib_path).localvqe_list_devices()
+
+
+# -- parity self-test (python -m sic_framework.services.localvqe.localvqe_binding) --
+
+def _read_wav_f32(path):
+    import wave
+
+    with wave.open(path, "rb") as w:
+        assert w.getcomptype() == "NONE", f"{path}: compressed WAV not supported"
+        assert w.getsampwidth() == 2, f"{path}: expected 16-bit PCM"
+        assert w.getnchannels() == 1, f"{path}: expected mono"
+        rate = w.getframerate()
+        data = w.readframes(w.getnframes())
+    return pcm16_to_f32(data), rate
+
+
+def _write_wav_f32(path, samples, rate=16000):
+    import wave
+
+    with wave.open(path, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(f32_to_pcm16(samples))
+
+
+def _synthetic_pair(seconds=2.0, rate=16000, seed=1234):
+    """Deterministic mic/ref pair: ref tone mix, mic = speech-ish + echo + noise."""
+    rng = np.random.default_rng(seed)
+    n = int(seconds * rate)
+    t = np.arange(n, dtype=np.float32) / rate
+    ref = 0.30 * np.sin(2 * np.pi * 440.0 * t) + 0.15 * np.sin(2 * np.pi * 660.0 * t)
+    ref = (ref * (0.5 + 0.5 * np.sin(2 * np.pi * 0.7 * t))).astype(np.float32)
+    near = 0.25 * np.sin(2 * np.pi * 220.0 * t) * (np.sin(2 * np.pi * 2.0 * t) > 0)
+    echo = 0.35 * np.concatenate([np.zeros(160, dtype=np.float32), ref[:-160]])
+    noise = rng.normal(0.0, 0.01, n).astype(np.float32)
+    mic = (near + echo + noise).astype(np.float32)
+    return np.clip(mic, -1, 1), np.clip(ref, -1, 1)
+
+
+def _selftest(argv=None):
+    import argparse
+    import subprocess
+    import tempfile
+
+    parser = argparse.ArgumentParser(description="LocalVQE ctypes binding parity self-test")
+    parser.add_argument("--model", default=None, help="path to .gguf (default: default_model_path())")
+    parser.add_argument("--lib", default=None, help="path to liblocalvqe.so")
+    parser.add_argument("--mic", default=None, help="mic WAV (16 kHz mono s16); default: synthetic")
+    parser.add_argument("--ref", default=None, help="far-end reference WAV; default: synthetic")
+    parser.add_argument("--cli", default=None, help="path to the localvqe CLI for cross-checking")
+    parser.add_argument("--out", default=None, help="write the enhanced audio to this WAV")
+    parser.add_argument("--tol", type=float, default=1e-4, help="max abs diff tolerance (float domain)")
+    args = parser.parse_args(argv)
+
+    if args.mic:
+        mic, rate = _read_wav_f32(args.mic)
+        if args.ref:
+            ref, ref_rate = _read_wav_f32(args.ref)
+            assert ref_rate == rate, "mic/ref sample-rate mismatch"
+            n = min(len(mic), len(ref))
+            mic, ref = mic[:n], ref[:n]
+        else:
+            ref = np.zeros_like(mic)
+    else:
+        mic, ref = _synthetic_pair()
+        rate = 16000
+
+    vqe = LocalVQE(model_path=args.model, lib_path=args.lib)
+    assert rate == vqe.sample_rate, f"input rate {rate} != model rate {vqe.sample_rate}"
+    hop = vqe.hop_length
+    n = (len(mic) // hop) * hop  # whole hops so streaming and batch cover the same span
+    mic, ref = mic[:n], ref[:n]
+    print(f"model={vqe.model_path}")
+    print(f"sample_rate={vqe.sample_rate} hop={hop} fft={vqe.fft_size} n_samples={n}")
+
+    # Whole clip
+    whole = vqe.process(mic, ref)
+
+    # Streaming: fresh state, then hop by hop
+    vqe.reset()
+    streamed = np.empty_like(whole)
+    for i in range(0, n, hop):
+        streamed[i:i + hop] = vqe.process_frame(mic[i:i + hop], ref[i:i + hop])
+
+    diff = float(np.max(np.abs(streamed - whole)))
+    rms = float(np.sqrt(np.mean((streamed - whole) ** 2)))
+    ok = diff <= args.tol
+    print(f"[stream-vs-whole] max_abs_diff={diff:.3e} rms_diff={rms:.3e} tol={args.tol:.1e} "
+          f"-> {'PASS' if ok else 'FAIL'}")
+
+    cli_ok = True
+    if args.cli:
+        with tempfile.TemporaryDirectory() as tmp:
+            mic_wav = args.mic or os.path.join(tmp, "mic.wav")
+            ref_wav = args.ref or os.path.join(tmp, "ref.wav")
+            if not args.mic:
+                _write_wav_f32(mic_wav, mic, rate)
+                _write_wav_f32(ref_wav, ref, rate)
+            out_wav = os.path.join(tmp, "cli_out.wav")
+            cmd = [args.cli, vqe.model_path, "--in-wav", mic_wav, ref_wav, "--out-wav", out_wav]
+            print("$ " + " ".join(cmd))
+            subprocess.check_call(cmd)
+            cli_out, cli_rate = _read_wav_f32(out_wav)
+            assert cli_rate == rate
+            m = min(len(cli_out), n)
+            # compare in the int16 domain: both paths saw the same s16 wav input
+            ours_i16 = np.frombuffer(f32_to_pcm16(whole[:m]), dtype="<i2")
+            cli_i16 = np.frombuffer(f32_to_pcm16(cli_out[:m]), dtype="<i2")
+            lsb = int(np.max(np.abs(ours_i16.astype(np.int32) - cli_i16.astype(np.int32))))
+            cli_ok = lsb <= 2  # allow rounding differences in the last bits
+            print(f"[binding-vs-cli] max_abs_diff={lsb} LSB (int16) over {m} samples "
+                  f"-> {'PASS' if cli_ok else 'FAIL'}")
+
+    if args.out:
+        _write_wav_f32(args.out, whole, rate)
+        print(f"enhanced audio written to {args.out}")
+
+    vqe.close()
+    return 0 if (ok and cli_ok) else 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(_selftest())

--- a/sic_framework/services/localvqe/localvqe_messages.py
+++ b/sic_framework/services/localvqe/localvqe_messages.py
@@ -1,0 +1,55 @@
+"""
+localvqe_messages.py
+
+Message and configuration types for the LocalVQE service.
+"""
+
+from sic_framework.core.message_python2 import (
+    AudioMessage,
+    SICConfMessage,
+    SICRequest,
+)
+
+
+class RefAudioMessage(AudioMessage):
+    """
+    Far-end reference audio (int16 PCM, 16 kHz mono): a distinct type so both
+    streams can share one connector without colliding in the input buffers.
+    """
+
+
+class LocalVQEResetRequest(SICRequest):
+    """Reset the LocalVQE streaming state and drop buffered samples."""
+
+
+class LocalVQEConf(SICConfMessage):
+    """
+    LocalVQE service configuration. model_path None resolves $LOCALVQE_MODEL,
+    then ~/.cache/sic/models/localvqe-v1.3-4.8M-f32.gguf. use_ref=True adds
+    the RefAudioMessage far-end stream for echo cancellation (both streams
+    must then keep flowing; a reference lagging max_ref_lag_seconds is
+    zero-filled). frontend_path is for the GTCRN model line only.
+    """
+
+    def __init__(
+        self,
+        model_path=None,
+        use_ref=False,
+        threads=None,
+        backend=None,
+        device=None,
+        frontend_path=None,
+        noise_gate_dbfs=None,
+        max_ref_lag_seconds=1.0,
+        lib_path=None,
+    ):
+        SICConfMessage.__init__(self)
+        self.model_path = model_path
+        self.use_ref = use_ref
+        self.threads = threads
+        self.backend = backend
+        self.device = device
+        self.frontend_path = frontend_path
+        self.noise_gate_dbfs = noise_gate_dbfs
+        self.max_ref_lag_seconds = max_ref_lag_seconds
+        self.lib_path = lib_path

--- a/sic_framework/services/localvqe/localvqe_service.py
+++ b/sic_framework/services/localvqe/localvqe_service.py
@@ -1,0 +1,203 @@
+"""
+localvqe_service.py
+
+SIC service for LocalVQE's GGML voice quality enhancement (AEC + noise
+suppression + dereverb) on 16 kHz mono audio. Run with `run-localvqe`.
+"""
+
+import numpy as np
+
+from sic_framework import SICComponentManager
+from sic_framework.core.connector import SICConnector
+from sic_framework.core.message_python2 import AudioMessage, SICSuccessMessage
+from sic_framework.core.service_python2 import SICService
+from sic_framework.services.localvqe.localvqe_binding import (
+    LocalVQE as LocalVQEBinding,
+    f32_to_pcm16,
+    pcm16_to_f32,
+)
+from sic_framework.services.localvqe.localvqe_messages import (
+    LocalVQEConf,
+    LocalVQEResetRequest,
+    RefAudioMessage,
+)
+
+
+class LocalVQEService(SICService):
+    """Voice quality enhancement service (AEC + NS + dereverb) backed by LocalVQE's GGML engine."""
+
+    COMPONENT_STARTUP_TIMEOUT = 60
+
+    def __init__(self, *args, **kwargs):
+        super(LocalVQEService, self).__init__(*args, **kwargs)
+
+        conf = self.params
+        self.vqe = LocalVQEBinding(
+            model_path=conf.model_path,
+            threads=conf.threads,
+            backend=conf.backend,
+            device=conf.device,
+            frontend_path=conf.frontend_path,
+            noise_gate_dbfs=conf.noise_gate_dbfs,
+            lib_path=conf.lib_path,
+        )
+        self._hop_bytes = self.vqe.hop_length * 2  # int16 PCM
+        self._mic_buf = bytearray()
+        self._ref_buf = bytearray()
+        self._warned_rate = False
+        self._warned_ref_lag = False
+        self._warned_ref_ignored = False
+
+        self.logger.info(
+            "LocalVQE ready: model={} sample_rate={} hop={} use_ref={} threads={} backend={}".format(
+                self.vqe.model_path,
+                self.vqe.sample_rate,
+                self.vqe.hop_length,
+                conf.use_ref,
+                conf.threads or "auto",
+                conf.backend or "CPU",
+            )
+        )
+
+    # Instance method (the framework calls self.get_inputs()): the aligner needs
+    # every declared input to flow, so the reference is declared only with use_ref.
+    def get_inputs(self):
+        if self.params.use_ref:
+            return [AudioMessage, RefAudioMessage]
+        return [AudioMessage]
+
+    @staticmethod
+    def get_output():
+        return AudioMessage
+
+    @staticmethod
+    def get_conf():
+        return LocalVQEConf()
+
+    def on_message(self, message):
+        # Redis TIME stamps are (sec, usec) tuples; the aligner subtracts
+        # timestamps, so flatten to float seconds before buffering.
+        if isinstance(message._timestamp, (tuple, list)):
+            message._timestamp = message._timestamp[0] + message._timestamp[1] / 1e6
+        # Without use_ref a stray RefAudioMessage (an AudioMessage subclass)
+        # would open an extra input buffer and stall alignment - drop it.
+        if not self.params.use_ref and message.get_message_name() == RefAudioMessage.get_message_name():
+            if not self._warned_ref_ignored:
+                self._warned_ref_ignored = True
+                self.logger.warning(
+                    "Ignoring RefAudioMessage stream: the service was started with "
+                    "use_ref=False (set LocalVQEConf(use_ref=True) for echo cancellation)"
+                )
+            return
+        super(LocalVQEService, self).on_message(message)
+
+    # Pair oldest-first: audio devices can deliver identical-timestamp doubles,
+    # which the newest-first default swaps or strands - FIFO keeps stream order.
+    def _find_aligned_message(self, buffer, reference_timestamp):
+        for message in reversed(buffer):
+            if abs(message._timestamp - reference_timestamp) <= self.MAX_TIMESTAMP_DIFF_SECONDS:
+                return message
+        return None
+
+    # Consume by identity: SICMessage.__eq__ is type-equality, so deque.remove
+    # would delete the newest same-type message instead of the one chosen above.
+    def _consume_messages(self, aligned_messages):
+        for buffer, message in aligned_messages:
+            for i, queued in enumerate(buffer):
+                if queued is message:
+                    del buffer[i]
+                    break
+
+    def on_request(self, request):
+        if isinstance(request, LocalVQEResetRequest):
+            self.vqe.reset()
+            del self._mic_buf[:]
+            del self._ref_buf[:]
+            self.logger.info("LocalVQE streaming state reset")
+            return SICSuccessMessage()
+        raise NotImplementedError("Unknown request type {}".format(type(request)))
+
+    def _check_message(self, message, name):
+        """Validate one input message; returns its PCM bytes (or None to skip)."""
+        if message.sample_rate != self.vqe.sample_rate:
+            if not self._warned_rate:
+                self._warned_rate = True
+                self.logger.error(
+                    "{} stream is {} Hz but LocalVQE requires {} Hz mono int16 PCM. "
+                    "Resample at the source (e.g. MicrophoneConf(sample_rate=16000)); "
+                    "dropping audio.".format(name, message.sample_rate, self.vqe.sample_rate)
+                )
+            return None
+        waveform = bytes(message.waveform)
+        if len(waveform) % 2:
+            self.logger.warning("{} chunk has odd byte length; dropping last byte".format(name))
+            waveform = waveform[:-1]
+        return waveform
+
+    def execute(self, inputs):
+        mic = self._check_message(inputs.get(AudioMessage), "mic")
+        if mic is None:
+            return None
+        self._mic_buf.extend(mic)
+
+        if self.params.use_ref:
+            ref = self._check_message(inputs.get(RefAudioMessage), "ref")
+            if ref is not None:
+                self._ref_buf.extend(ref)
+            # Zero-fill a lagging reference so enhancement never stalls.
+            max_lag_bytes = int(self.params.max_ref_lag_seconds * self.vqe.sample_rate) * 2
+            lag = len(self._mic_buf) - len(self._ref_buf)
+            if lag > max_lag_bytes:
+                if not self._warned_ref_lag:
+                    self._warned_ref_lag = True
+                    self.logger.warning(
+                        "Reference stream lags the mic stream by more than {:.2f}s; "
+                        "zero-filling the reference (echo cancellation degrades "
+                        "until it catches up)".format(self.params.max_ref_lag_seconds)
+                    )
+                self._ref_buf.extend(b"\x00" * lag)
+        else:
+            self._ref_buf.extend(b"\x00" * len(mic))
+
+        n_hops = min(len(self._mic_buf), len(self._ref_buf)) // self._hop_bytes
+        if n_hops == 0:
+            return None
+
+        take = n_hops * self._hop_bytes
+        mic_f = pcm16_to_f32(bytes(self._mic_buf[:take]))
+        ref_f = pcm16_to_f32(bytes(self._ref_buf[:take]))
+        del self._mic_buf[:take]
+        del self._ref_buf[:take]
+
+        hop = self.vqe.hop_length
+        out = np.empty(n_hops * hop, dtype=np.float32)
+        for i in range(0, n_hops * hop, hop):
+            out[i:i + hop] = self.vqe.process_frame(mic_f[i:i + hop], ref_f[i:i + hop])
+
+        return AudioMessage(
+            waveform=f32_to_pcm16(out),
+            sample_rate=self.vqe.sample_rate,
+            is_stream=True,
+        )
+
+    def _cleanup(self):
+        try:
+            self.vqe.close()
+        except Exception as e:
+            self.logger.warning("Error closing LocalVQE context: {}".format(e))
+
+
+class SICLocalVQE(SICConnector):
+    """Connector for the LocalVQE voice quality enhancement service."""
+
+    component_class = LocalVQEService
+    component_group = "LocalVQE"
+
+
+def main():
+    """Run a ComponentManager that can start the LocalVQE service."""
+    SICComponentManager([LocalVQEService], component_group="LocalVQE")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What is the current behavior?
A robot that speaks and listens at the same time hears itself. Its speaker output reaches its own microphone, so VAD, wake word and ASR all fight the robot's own playback. Acoustic echo cancellation fixes this by subtracting the known far-end signal (what the speaker is playing) from the mic input.

Reachy Mini's microphone array uses the reSpeaker XMOS XVF3800, which runs AEC, beamforming, dereverberation and noise suppression on-chip. Hardware AEC is a property of the audio front-end, not of robots in general. Any SIC device without that silicon, and any desktop application, has no echo cancellation. Its mic stream contains whatever the speakers are playing. SIC has nothing that addresses this today.

## What is the new behavior?
This PR adds LocalVQE: a small neural model (GGML, CPU, 16 ms hop) doing echo cancellation, noise suppression and dereverberation in software. It lets devices without an XMOS-class front-end hear a user through the robot's own voice, which is what makes barge-in possible.

[Li et al.](https://ieeexplore.ieee.org/abstract/document/10731262?casa_token=9x0NBKce5gMAAAAA:aE_JeH5_L1Fh0B2ooH2KPgW1fB8FzUK6MbRQr4kj5hU0CYXzvQYl1ivfty7IHpBoyFlPY6ZLrRM) framed the problem for social robots: ASR cannot separate overlapping speech, so robots like Pepper mute their microphone while speaking, which makes interruption impossible. They solve it by training a model to filter the robot's ego speech from a single-channel mic.

This PR takes the same goal with a different method. LocalVQE does acoustic echo cancellation: it takes the played audio as a live reference and subtracts it from the mic, per 256-sample hop.
LocalVQE is a streaming derivative of [DeepVQE (Ristea et al., Interspeech 2023)](https://www.isca-archive.org/interspeech_2023/ristea23_interspeech.html), reimplemented as a GGML graph and pruned down.

One difference in scope: Li et al. extract the human's speech for transcription. This service does not. The enhanced stream is used only to detect that the user has started speaking. 

### This is for interruption, not transcription
LocalVQE runs on the mic so the system can hear the user through its own playback. The enhanced stream answers one question: is the user speaking right now. That is all it is used for here. **_The enhanced audio is not meant for speech recognition. It is optimised for detecting speech, not preserving it._** 

The intended flow:
1. LocalVQE and VAD listen on the enhanced stream while the far-end plays.
2. VAD fires. The far-end (TTS) stops mid-sentence.
3. From that moment there is no echo to cancel, so ASR should use the raw, non-enhanced mic audio.

Once playback is silent, the raw mic is the better signal. The second demo shows the interruption only. The ASR handoff is not implemented, as well as the chunking synthesized TTS (see below).

### The TTS must synthesise in chunks
Barge-in means stopping playback at any point in the sentence. A TTS that returns one finished WAV per utterance cannot do this. The audio is already committed by the time the user speaks. The far-end must be produced and played in chunks so a pause can take effect between them.

The first demo plays a pre-recorded WAV in chunks as a stand-in. In a real system the far-end is a streaming TTS such as [Piper](https://github.com/OHF-Voice/piper1-gpl), where PiperVoice.synthesize yields chunks as they are generated:
```python
for chunk in voice.synthesize("..."):
    set_audio_format(chunk.sample_rate, chunk.sample_width, chunk.sample_channels)
    write_raw_data(chunk.audio_int16_bytes)
```
Each chunk is played and published as the reference. On barge-in the loop stops consuming the generator. Any chunked TTS works the same way.

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Possibly

The setup.py file has been adjusted for building and downloading the model during pip install with build_ext


## Other information

### Installation
The service compiles a native library from source, so you need a working C++ toolchain.

#### Linux (tested)
```
sudo apt install git cmake build-essential pkg-config libsndfile1-dev
```
Requires CMake 3.20 or newer. Check with cmake --version; Ubuntu 22.04 and later are fine.

#### macOS (untested)
```
brew install cmake pkg-config libsndfile
```
Xcode command line tools provide the compiler: xcode-select --install.

#### Windows (untested)
Not verified. The build hook and the binding were written and tested on Linux, and the loader expects liblocalvqe.so. On Windows the library builds as a .dll, so the loader needs a look before this can be relied on. What should be required:

Visual Studio 2019 or newer with the "Desktop development with C++" workload, or the standalone Build Tools for Visual Studio

```
CMake 3.20 or newer (winget install Kitware.CMake)
Git (winget install Git.Git)
libsndfile, most easily via vcpkg (vcpkg install libsndfile:x64-windows), with CMAKE_TOOLCHAIN_FILE pointing at the vcpkg toolchain
```

Run the install from a Developer Command Prompt so the compiler is on the path. If you hit problems, open an issue with the build output. Treating Windows as supported needs someone to run it end to end first.

